### PR TITLE
fix(metrics): guard reward reads against a non-dict rewards field

### DIFF
--- a/src/benchflow/metrics.py
+++ b/src/benchflow/metrics.py
@@ -16,6 +16,7 @@ from benchflow._utils.scoring import (
     classify_error,
     classify_score_outcome,
     classify_verifier_error,
+    extract_reward,
     pass_rate,
     pass_rate_excl_errors,
 )
@@ -318,13 +319,15 @@ class BenchmarkMetrics:
         }
 
 
-def _safe_reward(rewards: dict) -> float:
+def _safe_reward(rewards: Any) -> float:
     """Extract reward value from a rewards dict, defaulting to 0 if None/missing.
 
     Prevents TypeError when comparing reward values where one is None
-    (e.g. rewards={"reward": None, "rubric": [...]}).
+    (e.g. rewards={"reward": None, "rubric": [...]}), and AttributeError when
+    the persisted ``rewards`` is not a mapping at all — the resume path feeds
+    raw json.loads payloads with no shape validation.
     """
-    val = rewards.get("reward")
+    val = rewards.get("reward") if isinstance(rewards, dict) else None
     return val if isinstance(val, (int, float)) else 0.0
 
 
@@ -361,7 +364,7 @@ def collect_metrics(
 
     tasks = []
     for task_name, r in sorted(best.items()):
-        reward = r.get("rewards", {}).get("reward") if r.get("rewards") else None
+        reward = extract_reward(r)
         # Calculate duration
         duration = 0.0
         try:

--- a/src/benchflow/skill_eval/_core.py
+++ b/src/benchflow/skill_eval/_core.py
@@ -738,7 +738,7 @@ class SkillEvaluator:
                     try:
                         result_data = json.loads(result_file.read_text())
                         rewards = result_data.get("rewards")
-                        if rewards:
+                        if isinstance(rewards, dict):
                             reward = rewards.get(
                                 "reward", next(iter(rewards.values()), None)
                             )

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -232,6 +232,68 @@ def test_collect_metrics_corrupt_file(tmp_path):
     assert s["total"] == 0
 
 
+@pytest.mark.parametrize("rewards", [1.0, 1, True, [1.0], "1.0"])
+def test_collect_metrics_non_dict_rewards_counts_as_errored(tmp_path, rewards):
+    """A persisted non-dict `rewards` must not crash the aggregation.
+
+    Results are raw json.loads payloads with no shape validation, so `rewards`
+    can be any JSON value. Reading it as a mapping raised AttributeError and
+    killed `bench eval metrics` on the whole results dir. `extract_reward`
+    treats a non-mapping as no reward, which lands the task in the errored
+    bucket — the same reading `_classify_completed_outcomes` applies to the
+    identical payload.
+    """
+    trial = tmp_path / "job" / "task-a__abc"
+    trial.mkdir(parents=True)
+    (trial / "result.json").write_text(
+        json.dumps({"task_name": "task-a", "rewards": rewards})
+    )
+
+    metrics = collect_metrics(str(tmp_path))
+    s = metrics.summary()
+
+    assert metrics.tasks[0].reward is None
+    assert s["total"] == 1
+    assert s["errored"] == 1
+    assert s["errored_tasks"] == ["task-a"]
+
+
+def test_collect_metrics_non_dict_rewards_does_not_shadow_a_scored_retry(tmp_path):
+    """A malformed artifact must not win the best-result pick.
+
+    The selection step compares both artifacts' rewards; reading a non-dict
+    `rewards` raised inside the enclosing `except Exception`, which dropped the
+    *well-formed* retry for the same task and reported it as errored. Mirrors
+    test_scoring.py::test_malformed_rewards_shape_tolerated, which pins the
+    same invariant for mean_scored_reward.
+    """
+    job = tmp_path / "job"
+    for name, rewards, n_tool_calls in (
+        ("task-a__aaa", 1.0, 99),  # malformed, sorts first
+        ("task-a__zzz", {"reward": 1.0}, 7),
+    ):
+        trial = job / name
+        trial.mkdir(parents=True)
+        (trial / "result.json").write_text(
+            json.dumps(
+                {
+                    "task_name": "task-a",
+                    "rewards": rewards,
+                    "n_tool_calls": n_tool_calls,
+                }
+            )
+        )
+
+    metrics = collect_metrics(str(tmp_path))
+    s = metrics.summary()
+
+    assert s["total"] == 1
+    assert s["passed"] == 1
+    assert metrics.tasks[0].reward == 1.0
+    # The well-formed artifact is the one kept, not just its reward.
+    assert metrics.tasks[0].n_tool_calls == 7
+
+
 def test_collect_metrics_metadata(results_dir):
     """Test that benchmark/agent/model metadata is passed through."""
     metrics = collect_metrics(

--- a/tests/test_skill_eval.py
+++ b/tests/test_skill_eval.py
@@ -593,6 +593,52 @@ class TestSkillEvaluatorResultCollection:
         assert collected["case-1"].reward == 0.0
         assert collected["case-10"].reward == 1.0
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("rewards", [1.0, 1, True, [1.0], "1.0"])
+    async def test_non_dict_rewards_does_not_crash_collection(
+        self, skill_dir, tmp_path, monkeypatch, rewards
+    ):
+        """A persisted non-dict `rewards` must not abort `bench skills eval`.
+
+        Same failure mode as collect_metrics: the rollout's result.json is a
+        raw json.loads payload, and reading `rewards` as a mapping raised
+        AttributeError — which the enclosing
+        `except (json.JSONDecodeError, KeyError)` does not catch.
+        """
+        from benchflow.evaluation import EvaluationResult
+
+        async def fake_run(self):
+            rollout_dir = self._jobs_dir / "2026-09-04__10-00-00" / "calc-001__abc123"
+            rollout_dir.mkdir(parents=True)
+            (rollout_dir / "result.json").write_text(
+                json.dumps(
+                    {
+                        "task_name": "calc-001",
+                        "rewards": rewards,
+                        "n_tool_calls": 4,
+                    }
+                )
+            )
+            return EvaluationResult(job_name="fake", config=self._config, total=1)
+
+        monkeypatch.setattr("benchflow.evaluation.Evaluation.run", fake_run)
+
+        evaluator = SkillEvaluator(skill_dir)
+        results = await evaluator._run_job(
+            tasks_dir=tmp_path / "tasks",
+            agent="gemini",
+            model="",
+            environment="docker",
+            jobs_dir=str(tmp_path / "jobs"),
+            concurrency=1,
+            with_skill=True,
+        )
+
+        collected = {result.case_id: result for result in results}
+        assert collected["calc-001"].reward is None
+        assert collected["calc-001"].error is None
+        assert collected["calc-001"].n_tool_calls == 4
+
 
 class TestGepaExport:
     def test_exports_structure(self, skill_dir, tmp_path):


### PR DESCRIPTION
#1054 fixed `_classify_completed_outcomes`, so `bench eval run` now survives a
`result.json` whose `rewards` is not a mapping. The same payload still kills
`bench eval metrics`, and it aborts `bench skills eval` too. This closes both.

Reproduced on `3b9dd067` (main with #1054 merged), with #1054's own repro file:

```
$ bench eval metrics <jobs-dir>          # result.json has "rewards": 1.0
AttributeError: 'float' object has no attribute 'get'
  File "src/benchflow/metrics.py", line 364, in collect_metrics
    reward = r.get("rewards", {}).get("reward") if r.get("rewards") else None
exit 1
```

## Root cause

`result.json` is read back as a raw `json.loads` payload with no shape
validation, so `rewards` can be any JSON value. `r.get("rewards", {})` supplies
the `{}` default only when the key is *absent*; when the key is present with a
non-mapping value, the `.get` chain is applied to that value. The trailing
`if r.get("rewards")` guards falsiness, not shape.

The repo already has the total accessor for this -- `_utils/scoring.py:111`
`extract_reward`, which returns `None` for any non-mapping `rewards`. Every
reader of a persisted `rewards` in `src/` is isinstance-guarded already
(`review/runner.py:169`, `eval_lift.py:303`, `export_prime_sft.py:212`,
`viewer/payload.py:424`, `eval_artifacts.py:170`, `traj_capture.py:789`,
`loop_strategies.py:251`, and since #1054 `evaluation.py:435`). These two were
the last that were not.

## What changes

**`metrics.py:364`** -- the crash. `reward = extract_reward(r)`. A non-mapping
`rewards` now reads as no reward, so `TaskMetrics.score_outcome` routes the task
to `errored` through `classify_score_outcome` -- the same classifier, and the
same bucket, that #1054 gave the identical payload in `bench eval run`. The
failing line sits *outside* the enclosing `try`, which is why one malformed
artifact took down the aggregation for the whole results directory rather than
just that file.

**`metrics.py` `_safe_reward`** -- the same unguarded access, one level up in the
best-result selection, where it is *swallowed* rather than raised: it throws
inside the enclosing `except Exception`, which then logs "Skipping corrupt
result file" for the file being compared -- i.e. drops the **well-formed** retry
and lets the malformed artifact win the pick. Guarding it restores
`tests/test_scoring.py::test_malformed_rewards_shape_tolerated`'s invariant
("a malformed entry must not shadow a well-formed one") for `collect_metrics`.

**`skill_eval/_core.py:741`** -- `if rewards:` -> `if isinstance(rewards, dict):`.
Same failure mode, reached from `bench skills eval`; the enclosing handler
catches only `(json.JSONDecodeError, KeyError)`, so the `AttributeError`
propagates out of `_run_job`. `extract_reward` is deliberately **not** used here
because it would drop the existing `next(iter(rewards.values()), None)` fallback
and change `{"score": 0.7}` from `0.7` to `None`. The isinstance guard keeps
that behaviour exactly.

## What does not change

Measured A/B over every well-formed shape, both modules:

| `rewards` | `collect_metrics` | `_run_job` |
|---|---|---|
| `{"reward": 1.0}` | `1.0`, passed | `1.0` |
| `{"reward": 0.0}` | `0.0`, failed | `0.0` |
| `{"score": 0.7}` | -- | `0.7` (fallback preserved) |
| `null` | `None`, errored | `None` |
| `{}` | `None`, errored | `None` |

Identical before and after. The only inputs whose behaviour changes are the ones
that used to raise.

## Tests

11 new cases, all red on `3b9dd067` with the source change reverted and green
with it:

- `test_metrics.py::test_collect_metrics_non_dict_rewards_counts_as_errored`
  -- 5 payloads (`1.0`, `1`, `true`, `[1.0]`, `"1.0"`)
- `test_metrics.py::test_collect_metrics_non_dict_rewards_does_not_shadow_a_scored_retry`
  -- malformed + well-formed for one task; asserts the well-formed artifact is
  the one kept, not just its reward
- `test_skill_eval.py::TestSkillEvaluatorResultCollection::test_non_dict_rewards_does_not_crash_collection`
  -- same 5 payloads, using the class's existing
  `monkeypatch.setattr("benchflow.evaluation.Evaluation.run", ...)` idiom, so no
  docker and no provider key

Per-hunk mutation: each of the three source hunks reverted on its own is caught
by its own test, disjointly (3/3), so no hunk is unpinned and no test is
redundant.

## Verification

- `uv run ruff check src tests tools`: All checks passed!
- `uv run ruff format --check src tests tools`: 617 files already formatted
- `uv run ty check`: All checks passed!
- full suite: `1 failed, 5975 passed` with the change vs `1 failed, 5964 passed`
  on the untouched baseline -- +11 is exactly the new cases, and there are no
  head-only failures. The single failure,
  `test_integration_check_results.py::test_check_results_accepts_symlinked_current_repo_inferred_source`,
  is pre-existing and reproduces identically on the untouched baseline tree.
- CLI A/B: `bench eval metrics` on a jobs dir whose `result.json` carries
  `"rewards": 1.0` -- traceback and exit 1 before, normal table with `Errored 1`
  and exit 0 after.

## Known follow-up, deliberately not in this PR

With the guard in place a malformed artifact scores `0.0` in the selection, so
it can still tie out a well-formed artifact whose reward is `0.0` -- and
`collect_metrics` keeps the first-seen artifact on a tie, which is the module's
own determinism rule (`test_collect_metrics_best_result_picking`: "Both errored
(no rewards): first seen is kept"). Fixing that means making clause 2 of the
selection predicate (`r.get("rewards") is not None`) shape-aware, which is a
semantic change rather than a guard: `is not None` and `isinstance(..., dict)`
differ on `rewards: {}`, and truthiness differs again in clause 3, so a naive
swap would change which artifact wins for well-formed inputs. Happy to send it
separately if you want it.

This finishes the read path #1054 started: same payload, same classification,
the two sites it did not touch.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/1096" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->