### PR TITLE
feat(viewer): rubric tab showing the bench review report for a rollout

### DIFF
--- a/src/benchflow/trajectories/viewer/assets/detail.js
+++ b/src/benchflow/trajectories/viewer/assets/detail.js
@@ -633,10 +633,14 @@ BF.detail = (() => {
         const record = criterion && typeof criterion === "object" ? criterion : {};
         const row = el("tr");
         row.appendChild(el("td", null, record.name));
-        row.appendChild(el("td", null, record.blocker ? "blocker" : "weight " + (record.weight ?? "?")));
-        const verdict = el("td", null, record.blocker ? (record.outcome || "") : ((record.score ?? "?") + " / 2"));
-        if (record.blocker) {
-          verdict.style.color = record.outcome === "pass" ? "var(--ok-ink)" : "var(--bad-ink)";
+        // blocker true: v0.2 blocker; false: v0.2 scored; null: legacy v0.1 (outcome only)
+        const scored = record.blocker === false;
+        const kind = record.blocker === true ? "blocker" : (scored ? "weight " + (record.weight ?? "?") : "criterion");
+        row.appendChild(el("td", null, kind));
+        const verdict = el("td", null, scored ? ((record.score ?? "?") + " / 2") : (record.outcome || ""));
+        if (!scored && record.outcome) {
+          verdict.style.color = record.outcome === "pass" ? "var(--ok-ink)"
+            : (record.outcome === "fail" ? "var(--bad-ink)" : "var(--muted-foreground)");
         }
         row.appendChild(verdict);
         row.appendChild(el("td", null, record.explanation || ""));

--- a/src/benchflow/trajectories/viewer/assets/detail.js
+++ b/src/benchflow/trajectories/viewer/assets/detail.js
@@ -14,6 +14,7 @@ BF.detail = (() => {
     ["trace", "view-trace"],
     ["verifier", "view-verifier"],
     ["metrics", "view-metrics"],
+    ["rubric", "view-rubric"],
   ]);
   const STEP_KINDS = new Set(["prompt", "message", "thought", "tool", "timeout", "unknown"]);
   const TOOL_HUES = new Set(["read", "edit", "execute", "fetch", "search", "think", "skill", "other"]);
@@ -177,6 +178,9 @@ BF.detail = (() => {
       || meta.usage && typeof meta.usage === "object" && Object.keys(meta.usage).length
     ) {
       available.push(["metrics", "Metrics"]);
+    }
+    if (payload.rubric && typeof payload.rubric === "object") {
+      available.push(["rubric", "Rubric"]);
     }
 
     const tabs = document.getElementById("tabs");
@@ -581,6 +585,68 @@ BF.detail = (() => {
     if (!main.children.length) main.appendChild(el("div", "panelblock", "No verifier artifacts in this rollout."));
   }
 
+  function renderRubric(payload) {
+    const rubric = payload.rubric && typeof payload.rubric === "object" ? payload.rubric : null;
+    const main = document.getElementById("view-rubric");
+    main.textContent = "";
+    if (!rubric) {
+      main.appendChild(el("div", "panelblock", "No review report found for this rollout."));
+      return;
+    }
+    const scoring = rubric.scoring && typeof rubric.scoring === "object" ? rubric.scoring : {};
+    const head = el("div", "panelblock");
+    head.appendChild(el("h2", null, "Review"));
+    const facts = el("table", "plain");
+    const rows = [
+      ["Reviewer", rubric.reviewer_model || ""],
+      ["Valid", rubric.review_valid ? "yes" : "no"],
+      ["Verifier pass", scoring.deterministic_pass === undefined ? "" : (scoring.deterministic_pass ? "yes" : "no")],
+      ["Blockers", scoring.all_blockers_pass === undefined ? ""
+        : (scoring.all_blockers_pass ? "all pass" : "failed: " + (scoring.failed_blockers || []).join(", "))],
+      ["Raw quality", scoring.raw_quality === undefined ? "" : String(scoring.raw_quality)],
+      ["Gated quality", scoring.gated_quality === undefined ? "" : String(scoring.gated_quality)],
+      ["Decision", scoring.decision || ""],
+    ];
+    rows.forEach(([label, value]) => {
+      const row = el("tr");
+      row.appendChild(el("th", null, label));
+      const cell = el("td", null, value);
+      if (label === "Blockers" || label === "Verifier pass") {
+        cell.style.color = /fail|^no$/.test(value) ? "var(--bad-ink)" : (value ? "var(--ok-ink)" : "");
+      }
+      row.appendChild(cell);
+      facts.appendChild(row);
+    });
+    head.appendChild(facts);
+    if (rubric.summary) collapsibleText(head, rubric.summary, "body");
+    main.appendChild(head);
+
+    const criteria = Array.isArray(rubric.criteria) ? rubric.criteria : [];
+    if (criteria.length) {
+      const block = el("div", "panelblock");
+      block.appendChild(el("h2", null, "Criteria"));
+      const table = el("table", "plain");
+      const heading = el("tr");
+      ["Criterion", "Kind", "Verdict", "Reviewer note"].forEach((label) => heading.appendChild(el("th", null, label)));
+      table.appendChild(heading);
+      criteria.forEach((criterion) => {
+        const record = criterion && typeof criterion === "object" ? criterion : {};
+        const row = el("tr");
+        row.appendChild(el("td", null, record.name));
+        row.appendChild(el("td", null, record.blocker ? "blocker" : "weight " + (record.weight ?? "?")));
+        const verdict = el("td", null, record.blocker ? (record.outcome || "") : ((record.score ?? "?") + " / 2"));
+        if (record.blocker) {
+          verdict.style.color = record.outcome === "pass" ? "var(--ok-ink)" : "var(--bad-ink)";
+        }
+        row.appendChild(verdict);
+        row.appendChild(el("td", null, record.explanation || ""));
+        table.appendChild(row);
+      });
+      block.appendChild(table);
+      main.appendChild(block);
+    }
+  }
+
   function renderMetrics(payload) {
     const meta = payload.meta || {};
     const main = document.getElementById("view-metrics");
@@ -662,7 +728,7 @@ BF.detail = (() => {
   }
 
   function clearDetail() {
-    ["hdr", "tabs", "view-trace", "view-verifier", "view-metrics"].forEach((id) => {
+    ["hdr", "tabs", "view-trace", "view-verifier", "view-metrics", "view-rubric"].forEach((id) => {
       document.getElementById(id).textContent = "";
     });
     document.getElementById("toolbar").textContent = "";
@@ -702,6 +768,7 @@ BF.detail = (() => {
     renderTrace(payload);
     renderVerifier(payload);
     renderMetrics(payload);
+    renderRubric(payload);
     document.title = (payload.meta && payload.meta.task_name) || payload.rollout_name || "benchflow trajectory";
     if (options.focusHeading) requestAnimationFrame(() => heading.focus());
   }

--- a/src/benchflow/trajectories/viewer/assets/template.html
+++ b/src/benchflow/trajectories/viewer/assets/template.html
@@ -26,6 +26,7 @@
     <main id="view-trace" role="tabpanel"></main>
     <main id="view-verifier" role="tabpanel" class="hidden"></main>
     <main id="view-metrics" role="tabpanel" class="hidden"></main>
+    <main id="view-rubric" role="tabpanel" class="hidden"></main>
   </div>
 </div>
 <script id="bf-payload" type="application/json">__BENCHFLOW_PAYLOAD__</script>

--- a/src/benchflow/trajectories/viewer/models.py
+++ b/src/benchflow/trajectories/viewer/models.py
@@ -356,7 +356,9 @@ class RubricCriterion:
     """One rubric criterion as the reviewer judged it."""
 
     name: str
-    blocker: bool
+    # True for a v0.2 blocker, False for a v0.2 scored criterion, None for a
+    # legacy v0.1 criterion, which only carries an outcome.
+    blocker: bool | None
     weight: int | None
     outcome: str | None
     score: int | None

--- a/src/benchflow/trajectories/viewer/models.py
+++ b/src/benchflow/trajectories/viewer/models.py
@@ -352,11 +352,56 @@ class VerifierArtifacts:
 
 
 @dataclass(frozen=True)
+class RubricCriterion:
+    """One rubric criterion as the reviewer judged it."""
+
+    name: str
+    blocker: bool
+    weight: int | None
+    outcome: str | None
+    score: int | None
+    explanation: str
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "blocker": self.blocker,
+            "weight": self.weight,
+            "outcome": self.outcome,
+            "score": self.score,
+            "explanation": self.explanation,
+        }
+
+
+@dataclass(frozen=True)
+class RubricReview:
+    """The ``bench review`` verdict for one rollout, from ``review_report.json``."""
+
+    reviewer_model: str | None
+    review_valid: bool
+    scoring: JsonObject
+    summary: str
+    criteria: list[RubricCriterion]
+    source: str
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "reviewer_model": self.reviewer_model,
+            "review_valid": self.review_valid,
+            "scoring": dict(self.scoring),
+            "summary": self.summary,
+            "criteria": [criterion.to_payload() for criterion in self.criteria],
+            "source": self.source,
+        }
+
+
+@dataclass(frozen=True)
 class ViewerPayload:
     rollout_name: str
     meta: Meta
     steps: list[Step]
     verifier: VerifierArtifacts
+    rubric: RubricReview | None = None
     schema_version: int = 1
 
     def to_payload(self) -> dict[str, Any]:
@@ -366,6 +411,7 @@ class ViewerPayload:
             "meta": self.meta.to_payload(),
             "steps": [step.to_payload() for step in self.steps],
             "verifier": self.verifier.to_payload(),
+            "rubric": self.rubric.to_payload() if self.rubric is not None else None,
         }
 
 

--- a/src/benchflow/trajectories/viewer/payload.py
+++ b/src/benchflow/trajectories/viewer/payload.py
@@ -18,6 +18,8 @@ from .models import (
     Meta,
     PromptStep,
     RolloutMetadata,
+    RubricCriterion,
+    RubricReview,
     Step,
     StepCounts,
     ThoughtStep,
@@ -556,6 +558,96 @@ def _load_verifier(rollout_dir: Path) -> VerifierArtifacts:
     )
 
 
+# How far above a rollout directory review reports are looked for. Covers
+# ``jobs/<run>/<rollout>`` next to ``jobs/review-<stamp>/`` (bench review's
+# default) and deeper per-trial layouts.
+_REVIEW_SEARCH_DEPTH = 4
+_REVIEW_REPORT = "review_report.json"
+
+
+def _criteria(trial: dict[str, Any]) -> list[RubricCriterion]:
+    checks = trial.get("checks")
+    checks = checks if isinstance(checks, dict) else {}
+    metadata = trial.get("criterion_metadata")
+    rows: list[RubricCriterion] = []
+    for meta in metadata if isinstance(metadata, list) else []:
+        if not isinstance(meta, dict):
+            continue
+        name = _display_text(meta.get("name"))
+        check = checks.get(name)
+        check = check if isinstance(check, dict) else {}
+        score = check.get("score")
+        weight = meta.get("weight")
+        rows.append(
+            RubricCriterion(
+                name=name,
+                blocker=bool(meta.get("blocker")),
+                weight=weight
+                if isinstance(weight, int) and not isinstance(weight, bool)
+                else None,
+                outcome=_optional_text(check.get("outcome")),
+                score=score
+                if isinstance(score, int) and not isinstance(score, bool)
+                else None,
+                explanation=_display_text(check.get("explanation")),
+            )
+        )
+    return rows
+
+
+def _rubric_from_report(path: Path, rollout_name: str) -> RubricReview | None:
+    report = _load_json(path)
+    if not isinstance(report, dict):
+        return None
+    reviewer = report.get("reviewer")
+    model = (
+        _optional_text(reviewer.get("model")) if isinstance(reviewer, dict) else None
+    )
+    found: RubricReview | None = None
+    for trial in report.get("trials") or []:
+        if not isinstance(trial, dict) or trial.get("trial_name") != rollout_name:
+            continue
+        scoring = trial.get("scoring")
+        found = RubricReview(
+            reviewer_model=model,
+            review_valid=bool(trial.get("review_valid")),
+            scoring=dict(scoring) if isinstance(scoring, dict) else {},
+            summary=_display_text(trial.get("summary")),
+            criteria=_criteria(trial),
+            source=str(path),
+        )
+    return found
+
+
+def _load_rubric(rollout_dir: Path) -> RubricReview | None:
+    """Find the review of this rollout in the nearest ``review*`` directory.
+
+    The search walks up ``_REVIEW_SEARCH_DEPTH`` ancestors; at each level every
+    ``review*/**/review_report.json`` is read and the last valid entry for
+    this rollout in sorted order wins, the rule the leaderboard consumers use.
+    An invalid review (no scoring) never shadows a valid one.
+    """
+    name = rollout_dir.name
+    ancestor = rollout_dir
+    for _ in range(_REVIEW_SEARCH_DEPTH):
+        ancestor = ancestor.parent
+        found: RubricReview | None = None
+        for review_dir in sorted(ancestor.glob("review*")):
+            if not review_dir.is_dir():
+                continue
+            for path in sorted(review_dir.rglob(_REVIEW_REPORT)):
+                rubric = _rubric_from_report(path, name)
+                if rubric is None:
+                    continue
+                if rubric.scoring or found is None:
+                    found = rubric
+        if found is not None:
+            return found
+        if ancestor == ancestor.parent:
+            break
+    return None
+
+
 def _safe_json(obj: Any) -> str:
     """Emit strict, finite JSON and replace lone UTF-16 surrogates."""
     if not _within_json_depth(obj, max_depth=_MAX_JSON_OUTPUT_DEPTH):
@@ -581,6 +673,7 @@ def _build_acp_payload(rollout_dir: Path, prompts: list[str] | None) -> ViewerPa
         meta=_build_meta(_load_rollout_metadata(rollout_dir), steps),
         steps=steps,
         verifier=_load_verifier(rollout_dir),
+        rubric=_load_rubric(rollout_dir),
     )
 
 

--- a/src/benchflow/trajectories/viewer/payload.py
+++ b/src/benchflow/trajectories/viewer/payload.py
@@ -578,10 +578,11 @@ def _criteria(trial: dict[str, Any]) -> list[RubricCriterion]:
         check = check if isinstance(check, dict) else {}
         score = check.get("score")
         weight = meta.get("weight")
+        blocker = meta.get("blocker")
         rows.append(
             RubricCriterion(
                 name=name,
-                blocker=bool(meta.get("blocker")),
+                blocker=None if blocker is None else bool(blocker),
                 weight=weight
                 if isinstance(weight, int) and not isinstance(weight, bool)
                 else None,
@@ -604,7 +605,8 @@ def _rubric_from_report(path: Path, rollout_name: str) -> RubricReview | None:
         _optional_text(reviewer.get("model")) if isinstance(reviewer, dict) else None
     )
     found: RubricReview | None = None
-    for trial in report.get("trials") or []:
+    trials = report.get("trials")
+    for trial in trials if isinstance(trials, list) else []:
         if not isinstance(trial, dict) or trial.get("trial_name") != rollout_name:
             continue
         scoring = trial.get("scoring")

--- a/src/benchflow/trajectories/viewer/sources.py
+++ b/src/benchflow/trajectories/viewer/sources.py
@@ -26,6 +26,10 @@ _HF_VIEWER_FILES = (
     *(f"verifier/{name}" for name in VERIFIER_SIDECARS),
 )
 
+# bench review reports live beside the runs (``jobs/review-<stamp>/``), so a
+# scoped source also fetches its parent's review directories. Small JSON only.
+_HF_REVIEW_FILES = ("review_report.json",)
+
 _REPO_PART_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 _GLOB_METACHARACTERS = frozenset("*?[]")
 
@@ -147,6 +151,11 @@ def resolve_hf_dataset(source: HfDatasetSource) -> Path:
     for name in _HF_VIEWER_FILES:
         patterns.append(f"{scope}{name}")
         patterns.append(f"{scope}**/{name}")
+    parent = f"{'/'.join(subpath_parts[:-1])}/" if len(subpath_parts) > 1 else ""
+    for name in _HF_REVIEW_FILES:
+        patterns.append(f"{scope}**/{name}")
+        patterns.append(f"{parent}review*/{name}")
+        patterns.append(f"{parent}review*/**/{name}")
     print(
         f"Fetching {source.repo_id}"
         + (f" @ {source.revision}" if source.revision else "")

--- a/tests/trajectories/test_viewer_acp_renderer.py
+++ b/tests/trajectories/test_viewer_acp_renderer.py
@@ -640,8 +640,11 @@ class TestSources:
         assert root == tmp_path / "jobs" / "run-1"
         assert calls["repo_id"] == "org/name"
         assert calls["repo_type"] == "dataset"
-        assert all(p.startswith("jobs/run-1/") for p in calls["allow_patterns"])
+        rollout_patterns = [p for p in calls["allow_patterns"] if "review" not in p]
+        assert all(p.startswith("jobs/run-1/") for p in rollout_patterns)
         assert "jobs/run-1/trajectory/acp_trajectory.jsonl" in calls["allow_patterns"]
+        # review reports sit beside the run, so the parent's review-* dirs are in scope
+        assert "jobs/review*/**/review_report.json" in calls["allow_patterns"]
         assert not any("llm_trajectory" in p for p in calls["allow_patterns"])
 
     def test_resolve_raises_typed_error_for_missing_subpath(

--- a/tests/trajectories/test_viewer_acp_renderer.py
+++ b/tests/trajectories/test_viewer_acp_renderer.py
@@ -888,6 +888,7 @@ class TestTypedContract:
             "meta",
             "steps",
             "verifier",
+            "rubric",
         }
         assert wire["steps"][0] == {
             "i": 1,

--- a/tests/trajectories/test_viewer_rubric.py
+++ b/tests/trajectories/test_viewer_rubric.py
@@ -150,3 +150,78 @@ def test_rubric_tab_renders_in_the_browser(tmp_path: Path) -> None:
         assert "no_fabrication" in pane.inner_text()
         assert "presentable_with_revisions" in pane.inner_text()
         browser.close()
+
+
+def test_legacy_v01_criteria_keep_their_outcomes(tmp_path: Path) -> None:
+    """Guards the #1101 review finding: a v0.1 report (no blocker or weight,
+    outcome-only checks, no scoring) renders outcomes instead of "? / 2"."""
+    jobs = tmp_path / "jobs"
+    rollout = _rollout(jobs, "task__abcd1234")
+    out = jobs / "review-legacy"
+    out.mkdir()
+    (out / "review_report.json").write_text(
+        json.dumps(
+            {
+                "reviewer": {"model": "gateway/reviewer-x"},
+                "trials": [
+                    {
+                        "trial_name": "task__abcd1234",
+                        "review_valid": True,
+                        "summary": "ok",
+                        "criterion_metadata": [
+                            {"name": "cites_sources", "blocker": None, "weight": None}
+                        ],
+                        "checks": {
+                            "cites_sources": {"outcome": "fail", "explanation": "none"}
+                        },
+                        "scoring": None,
+                    }
+                ],
+            }
+        )
+    )
+    rubric = _load_rubric(rollout)
+    assert rubric is not None
+    criterion = rubric.criteria[0].to_payload()
+    assert criterion["blocker"] is None
+    assert criterion["outcome"] == "fail"
+    assert criterion["score"] is None
+    assert rubric.scoring == {}
+
+
+def test_malformed_trials_never_break_the_payload(tmp_path: Path) -> None:
+    """Guards the #1101 review finding: a report whose trials is not a list is
+    ignored instead of raising while the trajectory loads."""
+    jobs = tmp_path / "jobs"
+    rollout = _rollout(jobs, "task__abcd1234")
+    out = jobs / "review-bad"
+    out.mkdir()
+    (out / "review_report.json").write_text(json.dumps({"trials": {"oops": 1}}))
+    assert _load_rubric(rollout) is None
+    assert _build_acp_payload(rollout, None).to_payload()["rubric"] is None
+
+
+def test_hf_sources_fetch_sibling_review_reports(tmp_path: Path, monkeypatch) -> None:
+    """Guards the #1101 review finding: an hf:// source scoped to one run also
+    downloads the parent's review-* reports, and _load_rubric finds them."""
+    import huggingface_hub
+
+    from benchflow.trajectories.viewer.sources import (
+        HfDatasetSource,
+        resolve_hf_dataset,
+    )
+
+    calls: dict = {}
+
+    def fake_snapshot_download(*, repo_id, repo_type, revision, allow_patterns):
+        calls["allow_patterns"] = allow_patterns
+        _rollout(tmp_path / "jobs" / "run-1", "task__abcd1234")
+        _report(tmp_path / "jobs" / "review-x", "task__abcd1234", valid=True, gated=0.6)
+        return str(tmp_path)
+
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", fake_snapshot_download)
+    root = resolve_hf_dataset(HfDatasetSource("org/name", None, "jobs/run-1"))
+    assert "jobs/review*/**/review_report.json" in calls["allow_patterns"]
+    assert "jobs/run-1/**/review_report.json" in calls["allow_patterns"]
+    rubric = _load_rubric(root / "2026-01-01__00-00-00" / "task__abcd1234")
+    assert rubric is not None and rubric.scoring["gated_quality"] == 0.6

--- a/tests/trajectories/test_viewer_rubric.py
+++ b/tests/trajectories/test_viewer_rubric.py
@@ -1,0 +1,152 @@
+"""Rubric tab of the interactive viewer (issue #1101)."""
+
+from __future__ import annotations
+
+import json
+import socket
+import threading
+from pathlib import Path
+
+import pytest
+
+from benchflow.trajectories.viewer.payload import _build_acp_payload, _load_rubric
+
+
+def _rollout(jobs: Path, name: str) -> Path:
+    rollout = jobs / "2026-01-01__00-00-00" / name
+    (rollout / "trajectory").mkdir(parents=True)
+    (rollout / "trajectory" / "acp_trajectory.jsonl").write_text(
+        json.dumps(
+            {
+                "type": "tool_call",
+                "tool_call_id": "t1",
+                "kind": "execute",
+                "title": "ls",
+                "status": "completed",
+                "content": [],
+            }
+        )
+    )
+    (rollout / "result.json").write_text(json.dumps({"task_name": "t", "model": "m"}))
+    return rollout
+
+
+def _report(out_dir: Path, name: str, *, valid: bool, gated: float = 0.5) -> Path:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    trial: dict = {
+        "trial_name": name,
+        "review_valid": valid,
+        "summary": "Derivation complete, one unsupported claim.",
+        "criterion_metadata": [
+            {"name": "no_fabrication", "blocker": 1, "weight": 1},
+            {"name": "derivation", "blocker": 0, "weight": 5},
+        ],
+        "checks": {
+            "no_fabrication": {"outcome": "pass", "explanation": "cites the data"},
+            "derivation": {"score": 1, "explanation": "skips one step"},
+        },
+        "scoring": {
+            "deterministic_pass": True,
+            "all_blockers_pass": True,
+            "failed_blockers": [],
+            "raw_quality": gated,
+            "gated_quality": gated,
+            "decision": "presentable_with_revisions",
+        }
+        if valid
+        else None,
+    }
+    path = out_dir / "review_report.json"
+    path.write_text(
+        json.dumps({"reviewer": {"model": "gateway/reviewer-x"}, "trials": [trial]})
+    )
+    return path
+
+
+def test_rubric_is_found_in_the_sibling_review_dir(tmp_path: Path) -> None:
+    """The bench review default layout (jobs/review-<stamp>/ next to the run
+    directory) resolves without any configuration."""
+    jobs = tmp_path / "jobs"
+    rollout = _rollout(jobs, "task__abcd1234")
+    _report(
+        jobs / "review-2026-01-02__00-00-00", "task__abcd1234", valid=True, gated=0.7
+    )
+    rubric = _load_rubric(rollout)
+    assert rubric is not None
+    assert rubric.reviewer_model == "gateway/reviewer-x"
+    assert rubric.scoring["gated_quality"] == 0.7
+    assert [c.name for c in rubric.criteria] == ["no_fabrication", "derivation"]
+    assert rubric.criteria[0].blocker and rubric.criteria[0].outcome == "pass"
+    assert not rubric.criteria[1].blocker and rubric.criteria[1].score == 1
+
+
+def test_valid_review_wins_over_an_invalid_one_and_last_sorted_breaks_ties(
+    tmp_path: Path,
+) -> None:
+    """An invalid (unscored) entry never shadows a valid one; among valid
+    entries the last report in sorted order wins."""
+    jobs = tmp_path / "jobs"
+    rollout = _rollout(jobs, "task__abcd1234")
+    _report(jobs / "review-a", "task__abcd1234", valid=True, gated=0.2)
+    _report(jobs / "review-b", "task__abcd1234", valid=True, gated=0.9)
+    _report(jobs / "review-c", "task__abcd1234", valid=False)
+    rubric = _load_rubric(rollout)
+    assert rubric is not None
+    assert rubric.scoring["gated_quality"] == 0.9
+
+
+def test_other_rollouts_reports_and_missing_reports_yield_none(tmp_path: Path) -> None:
+    """A report for a different trial_name is not this rollout's review."""
+    jobs = tmp_path / "jobs"
+    rollout = _rollout(jobs, "task__abcd1234")
+    assert _load_rubric(rollout) is None
+    _report(jobs / "review-x", "other__00000000", valid=True)
+    assert _load_rubric(rollout) is None
+
+
+def test_payload_carries_the_rubric_section(tmp_path: Path) -> None:
+    """The rubric rides in the payload as its own section, null when absent."""
+    jobs = tmp_path / "jobs"
+    rollout = _rollout(jobs, "task__abcd1234")
+    assert _build_acp_payload(rollout, None).to_payload()["rubric"] is None
+    _report(jobs / "review-x", "task__abcd1234", valid=True, gated=0.4)
+    section = _build_acp_payload(rollout, None).to_payload()["rubric"]
+    assert section["scoring"]["decision"] == "presentable_with_revisions"
+    assert section["criteria"][1] == {
+        "name": "derivation",
+        "blocker": False,
+        "weight": 5,
+        "outcome": None,
+        "score": 1,
+        "explanation": "skips one step",
+    }
+
+
+def test_rubric_tab_renders_in_the_browser(tmp_path: Path) -> None:
+    """The Rubric tab appears for a reviewed rollout and lists the criteria."""
+    pw = pytest.importorskip("playwright.sync_api")
+    from benchflow.trajectories.viewer.server import _serve_browse
+
+    jobs = tmp_path / "jobs"
+    _rollout(jobs, "task__abcd1234")
+    _report(jobs / "review-x", "task__abcd1234", valid=True, gated=0.4)
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        port = probe.getsockname()[1]
+    threading.Thread(
+        target=_serve_browse,
+        args=(jobs, port, 1),
+        kwargs={"capped": False},
+        daemon=True,
+    ).start()
+
+    with pw.sync_playwright() as playwright:
+        browser = playwright.chromium.launch()
+        page = browser.new_page()
+        page.goto(f"http://localhost:{port}/")
+        page.locator(".runrow", has_text="task__abcd1234").first.click()
+        page.get_by_role("tab", name="Rubric").click()
+        pane = page.locator("#view-rubric")
+        assert "no_fabrication" in pane.inner_text()
+        assert "presentable_with_revisions" in pane.inner_text()
+        browser.close()


### PR DESCRIPTION
## Description

Adds a `Rubric` tab to the interactive viewer, filled from the `bench review` report of the rollout.

- `payload.py`: `_load_rubric` walks up to four ancestors of the rollout directory and reads every `review*/**/review_report.json` there (the `jobs/review-<stamp>/` layout `bench review` writes by default, and per-trial layouts). The entry whose `trial_name` is the rollout directory name is used; a valid (scored) entry never loses to an unscored one, and among valid entries the last in sorted order wins. Nothing is written.
- `models.py`: `RubricReview` (reviewer model, `review_valid`, scoring, summary, criteria, source path) and `RubricCriterion`; `ViewerPayload` gains an optional `rubric` section, `null` when no report exists.
- `detail.js` / `template.html`: the tab appears only when the payload carries a rubric. It shows reviewer, validity, verifier pass, blockers (with the failed ones named), raw and gated quality, decision, the reviewer summary, and a criteria table (blocker pass/fail or `n / 2`, with the reviewer's note).

## Motivation and Context

Closes #1101. Auditing a trajectory today means the trace, the Verifier tab, the Metrics tab, and then a hand search for the matching `trials[]` entry in a report file. The rubric verdict is the number that decides publishability, so it belongs next to the trace.

## How Has This Been Tested?

- `tests/trajectories/test_viewer_rubric.py`: discovery in the sibling `review-<stamp>` directory, valid-over-invalid and last-sorted-wins, other rollouts' reports ignored, payload section shape, and a playwright test that opens a reviewed rollout and reads the criteria from the Rubric tab.
- `test_payload_roundtrip_shape` updated for the new top-level key (shape change only).
- `pytest tests/`: 5997 passed, 57 skipped. `ruff check`, `ruff format --check`, `ty check src/` clean.
- Manual: the FrontierPhysics batch (270 reviewed rollouts) through this branch.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/1102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->