### PR TITLE
Release BenchFlow 0.7.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## 0.7.6 — 2026-09-04
+
 ### Added
 - **ACP rollout directories render as an interactive reviewer page.**
   `bench eval view <rollout>` now assembles a JSON payload (normalized
@@ -42,6 +44,48 @@
   timestamps.** Steps gain a `+m:ss` offset chip and tool calls a duration
   chip whenever events carry `ts` / `started_at` / `finished_at` fields;
   with today's captures (which carry none) nothing changes visually.
+- **Z.ai Coding Plan routing.** Coding Plan subscriptions route through the
+  provider layer, with validated generation parameters forwarded and explicit
+  provider endpoints preserved by the LiteLLM proxy. (#1074)
+- **`bench eval run` publishes job artifacts and eval results.**
+  `--publish-bucket` syncs a job directory to a HuggingFace storage bucket (an
+  alternative to `--publish-hf`'s dataset-repo upload), and
+  `--eval-results-model/-dataset/-task` opens a community eval-results PR
+  (`.eval_results/*.yaml`) on a model's HF repo, scored from the run's mean
+  reward. (#1035)
+
+### Fixed
+
+- **`claude-fable-5-1` can run: the `claude-agent-acp` pin moves 0.40.0 to
+  0.73.0.** The old pin bundled `@anthropic-ai/claude-agent-sdk` 0.3.160, and
+  the model rejects Claude Code older than 2.1.251 with
+  `claude_code_version_too_old` (HTTP 400) — so every rollout failed on its
+  first API call. The new pin bundles sdk 0.3.257, and the `set_config_option`
+  `"model"` / `"effort"` wiring is re-verified against it by
+  `tests/test_acp_pinned_protocol_guard.py`. (#1086)
+- **`codex-acp` dispatch modernized.** The shim pin moves to 1.6.0 and
+  reasoning effort travels inside the model id (`modelId[effort]`) through
+  `session/set_model`, rather than a config option the shim rejects. (#1044)
+- **ACP usage and terminal evidence survive an agent timeout**, instead of
+  being dropped with the timed-out turn. (#1080)
+- **A pending tool call can no longer defer the idle watchdog without
+  bound** — the deferral is capped. (#1066)
+- **`bench eval` resume re-runs infra-retryable verifier-errored tasks**
+  rather than treating the infrastructure failure as a settled result. (#1063)
+- **Sandbox hardening execs draw on the verifier-setup budget**, so hardening
+  no longer competes with the agent's own time. (#1062)
+- **`--trials > 1` without `--matrix` is rejected up front.** (#1064)
+- **Healthy native ACP subscription results are preserved.** (#1049)
+- **The agent judge parses native edit targets.** (#1069)
+- **Non-dict rewards no longer break completed-outcome classification.** (#1054)
+- **Codex honors proxy-owned model selection.** (#1076)
+- **Gemini routing corrections.** ACP model ids fixed and wrapped ids
+  normalized, Gemma routing supported with pass-through usage captured, every
+  Google key alias routed through the proxy, Google Gemini gateway routes
+  normalized, and headless runs trust the sandbox workspace.
+- **LiteLLM provisions the Vertex sandbox runtime.** (#985)
+- **OpenClaw caps supported model output tokens.**
+- **RestrictedPython updated to 8.3.**
 
 ## 0.7.5 — 2026-08-19
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "benchflow"
-version = "0.7.6.dev0"
+version = "0.7.6"
 description = "Multi-turn agent benchmarking with ACP — run any agent, any model, any provider."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -362,7 +362,7 @@ wheels = [
 
 [[package]]
 name = "benchflow"
-version = "0.7.6.dev0"
+version = "0.7.6"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
Cuts the first public release since 0.7.5 (2026-08-19), covering 25 commits on `main`.

Sets `[project].version` to `0.7.6` (from `0.7.6.dev0`), syncs `uv.lock`, and opens the `0.7.6` CHANGELOG section. Once this merges, pushing `v0.7.6` triggers `public-release.yml` (PyPI + GitHub Release); `main` then bumps to `0.7.7.dev0`.

## Why now

`claude-fable-5-1` is unusable on every stable install. Released 0.7.5 pins `@agentclientprotocol/claude-agent-acp@0.40.0`, which bundles `@anthropic-ai/claude-agent-sdk` 0.3.160; the model rejects Claude Code older than 2.1.251 with `claude_code_version_too_old` (HTTP 400), so rollouts fail on the first API call. #1086 fixed that on `main` on 2026-09-01, but no tagged release contains it — stable users have been stuck patching `site-packages` by hand or opting into `--prerelease allow`.

## Release contents

**Added** — reviewer-grade trajectory viewer and rollout catalog with `hf://` browsing (#1034), Z.ai Coding Plan routing (#1074), `--publish-bucket` and `--eval-results-*` on `bench eval run` (#1035).

**Fixed** — the `claude-agent-acp` 0.73.0 pin (#1086), modernized `codex-acp` dispatch (#1044), ACP usage/terminal evidence on timeout (#1080), idle-watchdog deferral cap (#1066), resume of infra-retryable verifier errors (#1063), verifier-setup budget for hardening execs (#1062), `--trials`/`--matrix` validation (#1064), plus the Gemini, LiteLLM, Codex and OpenClaw routing corrections. Full list in the CHANGELOG diff.

## Verification

- `main` is green at `3b9dd067` — `integration-light` and `internal-preview-release` both succeeded 2026-09-04.
- `uv lock --check` clean.
- `TAG_NAME=v0.7.6 uv run --with packaging --no-project python tools/release_version.py public-release` → `version=0.7.6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/1103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->