### PR TITLE
Bump BenchFlow to 0.7.7.dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "benchflow"
-version = "0.7.6"
+version = "0.7.7.dev0"
 description = "Multi-turn agent benchmarking with ACP — run any agent, any model, any provider."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -362,7 +362,7 @@ wheels = [
 
 [[package]]
 name = "benchflow"
-version = "0.7.6"
+version = "0.7.7.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
Step 5 of the public release flow in `docs/release.md`, following [v0.7.6](https://github.com/benchflow-ai/benchflow/releases/tag/v0.7.6).

`main` currently carries the final public version `0.7.6`, which makes `internal-preview-release.yml` skip publishing (`compute_internal_preview_version` only publishes from a plain `.dev` line). Restoring the next development line re-enables automatic preview builds: `0.7.7.dev0` in git becomes `0.7.7.dev<run-number>` on PyPI, sorting before the eventual public 0.7.7.

`uv lock --check` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/1104" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->