### PR TITLE
Post-hoc cost from recorded usage + OAuth-mode usage capture (bench cost, pricing table, OTEL receiver)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## [Unreleased]
 
+### Added
+- **Post-hoc cost from recorded usage (`bench cost`).** New `benchflow/pricing.py`
+  holds a version-stamped table of official list prices per model (input /
+  output / cache read / cache write 5m+1h, USD per MTok) and
+  `benchflow/cost.py` recomputes `total_cost_usd` for any rollout dir from
+  per-turn usage — `trajectory/llm_trajectory.jsonl` (LiteLLM), the new
+  `trajectory/otel_usage.jsonl` (OAuth capture), or the `result.json`
+  aggregate — with `--write` (cost_recompute.json) and `--update-result`
+  (rewrites `final_metrics.total_cost_usd`, keeps `agent_result.cost_history`).
+  A second table reproduces the prices LiteLLM applied in the FrontierPhysics
+  2026-09 run, which charged cache writes at 0.25x input instead of 1.25x.
+- **OAuth / subscription-mode usage capture.** `benchflow/otel_capture.py`
+  provides an OTLP/HTTP JSON receiver that turns Claude Code's
+  `claude_code.api_request` telemetry (model, input / output / cache-read /
+  cache-creation tokens, duration, request id, query source) into
+  `trajectory/otel_usage.jsonl`, plus `agent_env()` with the environment the
+  agent needs (`CLAUDE_CODE_ENABLE_TELEMETRY=1`, `OTEL_LOGS_EXPORTER=otlp`,
+  `OTEL_EXPORTER_OTLP_PROTOCOL=http/json`, endpoint). Wiring it into `Rollout`
+  is a follow-up.
+
 ## 0.7.6 — 2026-09-04
 
 ### Added

--- a/src/benchflow/cli/cost.py
+++ b/src/benchflow/cli/cost.py
@@ -1,0 +1,130 @@
+"""``bench cost`` — recompute rollout cost post hoc from recorded usage."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+from benchflow.cost import recompute_rollout_cost, update_result_json, write_cost_report
+from benchflow.pricing import PRICE_TABLES, price_table
+
+
+def _find_rollout_dirs(paths: list[Path]) -> list[Path]:
+    """Expand each path to rollout dirs (a dir with result.json, or its descendants)."""
+    found: list[Path] = []
+    for p in paths:
+        p = p.expanduser()
+        if (p / "result.json").is_file():
+            found.append(p)
+        elif p.is_dir():
+            found.extend(sorted(r.parent for r in p.rglob("result.json")))
+    return found
+
+
+def cost_command(
+    paths: Annotated[
+        list[Path] | None,
+        typer.Argument(help="Rollout dir(s), or parent dirs to scan for result.json."),
+    ] = None,
+    pricing: Annotated[
+        str,
+        typer.Option(
+            "--pricing",
+            help="Price table: 'list' (official list prices) or a table version.",
+        ),
+    ] = "list",
+    source: Annotated[
+        str,
+        typer.Option(
+            "--source", help="auto | llm_trajectory | otel_usage | result_aggregate"
+        ),
+    ] = "auto",
+    write: Annotated[
+        bool,
+        typer.Option(
+            "--write", help="Write cost_recompute.json into each rollout dir."
+        ),
+    ] = False,
+    update_result: Annotated[
+        bool,
+        typer.Option(
+            "--update-result",
+            help="Also rewrite final_metrics.total_cost_usd in result.json.",
+        ),
+    ] = False,
+    as_json: Annotated[
+        bool, typer.Option("--json", help="Print the full report(s) as JSON.")
+    ] = False,
+    list_tables: Annotated[
+        bool,
+        typer.Option("--list-tables", help="Print the known price tables and exit."),
+    ] = False,
+) -> None:
+    """Recompute total_cost_usd for rollout dirs from per-turn usage and list prices."""
+    if list_tables:
+        seen = set()
+        for name, table in PRICE_TABLES.items():
+            if table.version in seen:
+                continue
+            seen.add(table.version)
+            typer.echo(json.dumps({"name": name, **table.to_dict()}, indent=2))
+        raise typer.Exit()
+    try:
+        table = price_table(pricing)
+    except KeyError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(2) from None
+    if source not in ("auto", "llm_trajectory", "otel_usage", "result_aggregate"):
+        typer.echo(f"invalid --source {source!r}", err=True)
+        raise typer.Exit(2)
+
+    dirs = _find_rollout_dirs(paths or [])
+    if not dirs:
+        typer.echo("no rollout dirs (result.json) found", err=True)
+        raise typer.Exit(1)
+
+    reports = []
+    for d in dirs:
+        report = recompute_rollout_cost(d, pricing=table, source=source)  # type: ignore[arg-type]
+        reports.append(report)
+        if write:
+            write_cost_report(report)
+        if update_result:
+            update_result_json(report)
+        if not as_json:
+            rec = (
+                "n/a"
+                if report.recorded_cost_usd is None
+                else f"{report.recorded_cost_usd:.4f}"
+            )
+            tot = (
+                "UNPRICED"
+                if report.total_cost_usd is None
+                else f"{report.total_cost_usd:.4f}"
+            )
+            delta = (
+                "" if report.delta_usd is None else f"  delta {report.delta_usd:+.4f}"
+            )
+            models = ", ".join(m.model for m in report.per_model) or "-"
+            typer.echo(
+                f"{d}: {tot} USD ({table.version}, {report.source}, {report.n_records} records, {models})"
+                f"  recorded {rec}{delta}"
+            )
+    if as_json:
+        typer.echo(json.dumps([r.to_dict() for r in reports], indent=2, default=str))
+    if len(reports) > 1 and not as_json:
+        priced = [r for r in reports if r.total_cost_usd is not None]
+        total = sum(r.total_cost_usd or 0 for r in priced)
+        recorded = sum(
+            r.recorded_cost_usd or 0 for r in priced if r.recorded_cost_usd is not None
+        )
+        typer.echo(
+            f"TOTAL {len(priced)}/{len(reports)} priced: {total:.2f} USD ({table.version}); recorded {recorded:.2f} USD"
+        )
+
+
+def register_cost(app: typer.Typer) -> None:
+    app.command("cost", rich_help_panel="Core")(cost_command)

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -47,6 +47,7 @@ from benchflow.cli._shared import (
 from benchflow.cli.adopt import register_adopt_deprecated, register_eval_adopt
 from benchflow.cli.agent import register_agent
 from benchflow.cli.continue_cmd import register_continue
+from benchflow.cli.cost import register_cost
 from benchflow.cli.environment import register_environment
 from benchflow.cli.eval_artifacts import postprocess_eval_artifacts, run_matrix_eval
 from benchflow.cli.eval_lift import register_eval_lift
@@ -1314,6 +1315,7 @@ register_traj(app)
 register_train(app)
 register_hub(app)
 register_agent(app)
+register_cost(app)
 register_adopt_deprecated(app)
 register_sandbox(app)
 register_environment(app)

--- a/src/benchflow/cost.py
+++ b/src/benchflow/cost.py
@@ -1,0 +1,369 @@
+"""Post-hoc cost recomputation for a rollout directory.
+
+``recompute_rollout_cost(rollout_dir)`` reads per-turn usage from whichever
+capture the run produced and prices it with :mod:`benchflow.pricing`:
+
+1. ``trajectory/llm_trajectory.jsonl`` — LiteLLM proxy capture (API-key mode).
+   One :class:`~benchflow.trajectories.types.LLMExchange` per line; usage comes
+   from ``response.body.usage`` (provider convention, normalized by
+   ``_exchange_token_usage``), the model from ``metadata.provider_model`` /
+   ``response.body.model``.
+2. ``trajectory/otel_usage.jsonl`` — OAuth / subscription mode capture written
+   by :mod:`benchflow.otel_capture` from Claude Code's ``claude_code.api_request``
+   telemetry events. One request per line with uncached ``input_tokens``,
+   ``output_tokens``, ``cache_read_tokens``, ``cache_creation_tokens``, ``model``.
+3. ``result.json`` aggregate — ``agent_result.n_*_tokens`` (whole-run totals) as
+   the fallback when neither per-turn file exists. ``usage_source`` decides the
+   input convention: ``provider_response`` is cache-inclusive (LiteLLM path),
+   ``agent_native_acp`` is uncached (claude-agent-acp forwards the SDK's raw
+   ``inputTokens``).
+
+The result is a :class:`CostReport` with per-model token totals and cost, the
+recorded ``final_metrics.total_cost_usd`` for comparison, and the price table
+version. ``--update-result`` writes the recomputed cost back into
+``result.json`` (``final_metrics.total_cost_usd``, ``agent_result.cost_usd``,
+``agent_result.price_source``) keeping the previous values under
+``agent_result.cost_history``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Literal
+
+from benchflow.pricing import (
+    LIST_PRICES,
+    PriceTable,
+    UnknownModelPrice,
+    UsageCounts,
+    canonical_model,
+    compute_cost,
+    price_table,
+)
+
+logger = logging.getLogger(__name__)
+
+UsageSourceKind = Literal["llm_trajectory", "otel_usage", "result_aggregate"]
+OTEL_USAGE_FILENAME = "otel_usage.jsonl"
+LLM_TRAJECTORY_FILENAME = "llm_trajectory.jsonl"
+
+
+@dataclass
+class ModelCost:
+    model: str
+    n_records: int = 0
+    usage: UsageCounts = field(default_factory=UsageCounts)
+    cost_usd: float | None = None
+    breakdown: dict[str, float] = field(default_factory=dict)
+    unpriced: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "model": self.model,
+            "canonical_model": canonical_model(self.model),
+            "n_records": self.n_records,
+            "input_tokens_uncached": self.usage.input_tokens,
+            "output_tokens": self.usage.output_tokens,
+            "cache_read_tokens": self.usage.cache_read_tokens,
+            "cache_creation_tokens": self.usage.cache_creation_tokens,
+            "cache_creation_1h_tokens": self.usage.cache_creation_1h_tokens,
+            "input_tokens_inclusive": self.usage.total_input_inclusive,
+            "cost_usd": self.cost_usd,
+            "breakdown_usd": self.breakdown,
+            "unpriced": self.unpriced,
+        }
+
+
+@dataclass
+class CostReport:
+    rollout_dir: str
+    source: UsageSourceKind
+    source_path: str
+    pricing_version: str
+    n_records: int
+    per_model: list[ModelCost]
+    total_cost_usd: float | None
+    recorded_cost_usd: float | None
+    recorded_price_source: str | None
+    recorded_usage_source: str | None
+    unpriced_models: list[str]
+    computed_at: str
+
+    @property
+    def delta_usd(self) -> float | None:
+        if self.total_cost_usd is None or self.recorded_cost_usd is None:
+            return None
+        return self.total_cost_usd - self.recorded_cost_usd
+
+    def to_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        d["per_model"] = [m.to_dict() for m in self.per_model]
+        d["delta_usd"] = self.delta_usd
+        d["usage_totals"] = sum(
+            (m.usage for m in self.per_model), UsageCounts()
+        ).__dict__
+        return d
+
+
+# ---------------------------------------------------------------- readers
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        logger.warning("unreadable JSON %s: %s", path, exc)
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def usage_records_from_llm_trajectory(
+    path: Path, *, default_model: str | None = None
+) -> list[tuple[str, UsageCounts]]:
+    """(model, usage) per successful exchange in ``llm_trajectory.jsonl``."""
+    from benchflow.trajectories.types import LLMExchange, _exchange_token_usage
+
+    records: list[tuple[str, UsageCounts]] = []
+    for lineno, raw in enumerate(path.read_text().splitlines(), start=1):
+        if not raw.strip():
+            continue
+        try:
+            ex = LLMExchange.model_validate_json(raw)
+        except Exception as exc:  # malformed line: skip, do not abort
+            logger.warning("skipping malformed %s line %d: %s", path.name, lineno, exc)
+            continue
+        body = ex.response.body if isinstance(ex.response.body, dict) else {}
+        usage = body.get("usage")
+        if not isinstance(usage, dict) or not any(
+            v is not None for v in usage.values()
+        ):
+            continue  # failed call or no usage: nothing billed
+        tu = _exchange_token_usage(ex)
+        cc = usage.get("cache_creation")
+        one_hour = 0
+        if isinstance(cc, dict):
+            try:
+                one_hour = int(cc.get("ephemeral_1h_input_tokens") or 0)
+            except (TypeError, ValueError):
+                one_hour = 0
+        counts = UsageCounts.from_inclusive_input(
+            input_tokens_inclusive=tu.input_tokens,
+            output_tokens=tu.output_tokens,
+            cache_read_tokens=tu.cache_read_tokens,
+            cache_creation_tokens=tu.cache_creation_tokens,
+            cache_creation_1h_tokens=one_hour,
+        )
+        model = (
+            ex.metadata.get("provider_model")
+            or body.get("model")
+            or ex.metadata.get("request_model")
+            or ex.metadata.get("model_group")
+            or (ex.request.body or {}).get("model")
+            or default_model
+            or "unknown"
+        )
+        records.append((str(model), counts))
+    return records
+
+
+def usage_records_from_otel_usage(
+    path: Path, *, default_model: str | None = None
+) -> list[tuple[str, UsageCounts]]:
+    """(model, usage) per ``api_request`` record in ``otel_usage.jsonl``."""
+    records: list[tuple[str, UsageCounts]] = []
+    seen_request_ids: set[str] = set()
+    for lineno, raw in enumerate(path.read_text().splitlines(), start=1):
+        if not raw.strip():
+            continue
+        try:
+            rec = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            logger.warning("skipping malformed %s line %d: %s", path.name, lineno, exc)
+            continue
+        if not isinstance(rec, dict) or rec.get("event") not in (None, "api_request"):
+            continue
+        rid = rec.get("request_id")
+        if isinstance(rid, str) and rid:
+            if rid in seen_request_ids:
+                continue  # duplicate export of the same request
+            seen_request_ids.add(rid)
+        counts = UsageCounts.from_anthropic_usage(rec)
+        model = rec.get("model") or default_model or "unknown"
+        records.append((str(model), counts))
+    return records
+
+
+def usage_records_from_result_aggregate(
+    result: dict[str, Any],
+) -> list[tuple[str, UsageCounts]]:
+    """Whole-run totals from ``result.json`` as a single (model, usage) record."""
+    ar = result.get("agent_result") or {}
+    fm = result.get("final_metrics") or {}
+    model = str(result.get("model") or ar.get("model") or "unknown")
+    usage_source = ar.get("usage_source") or (result.get("usage_tracking") or {}).get(
+        "usage_source"
+    )
+    n_in = int(ar.get("n_input_tokens") or fm.get("total_prompt_tokens") or 0)
+    n_out = int(ar.get("n_output_tokens") or fm.get("total_completion_tokens") or 0)
+    n_cr = int(ar.get("n_cache_read_tokens") or fm.get("total_cached_tokens") or 0)
+    n_cw = int(ar.get("n_cache_creation_tokens") or 0)
+    if n_in == 0 and n_out == 0:
+        return []
+    if usage_source == "agent_native_acp":
+        # claude-agent-acp forwards the SDK's raw inputTokens (uncached).
+        counts = UsageCounts(n_in, n_out, n_cr, n_cw)
+    else:
+        counts = UsageCounts.from_inclusive_input(
+            input_tokens_inclusive=n_in,
+            output_tokens=n_out,
+            cache_read_tokens=n_cr,
+            cache_creation_tokens=n_cw,
+        )
+    return [(model, counts)]
+
+
+# ---------------------------------------------------------------- recompute
+
+
+def detect_source(rollout_dir: Path) -> tuple[UsageSourceKind, Path]:
+    traj = rollout_dir / "trajectory"
+    if (traj / LLM_TRAJECTORY_FILENAME).is_file():
+        return "llm_trajectory", traj / LLM_TRAJECTORY_FILENAME
+    if (traj / OTEL_USAGE_FILENAME).is_file():
+        return "otel_usage", traj / OTEL_USAGE_FILENAME
+    return "result_aggregate", rollout_dir / "result.json"
+
+
+def recompute_rollout_cost(
+    rollout_dir: str | Path,
+    *,
+    pricing: str | PriceTable | None = None,
+    source: UsageSourceKind | Literal["auto"] = "auto",
+) -> CostReport:
+    rollout_dir = Path(rollout_dir).expanduser()
+    table = (
+        pricing
+        if isinstance(pricing, PriceTable)
+        else price_table(pricing)
+        if pricing
+        else LIST_PRICES
+    )
+    result = _read_json(rollout_dir / "result.json") or {}
+    default_model = result.get("model")
+
+    if source == "auto":
+        kind, path = detect_source(rollout_dir)
+    else:
+        kind = source
+        path = {
+            "llm_trajectory": rollout_dir / "trajectory" / LLM_TRAJECTORY_FILENAME,
+            "otel_usage": rollout_dir / "trajectory" / OTEL_USAGE_FILENAME,
+            "result_aggregate": rollout_dir / "result.json",
+        }[kind]
+
+    if kind == "llm_trajectory":
+        records = (
+            usage_records_from_llm_trajectory(path, default_model=default_model)
+            if path.is_file()
+            else []
+        )
+    elif kind == "otel_usage":
+        records = (
+            usage_records_from_otel_usage(path, default_model=default_model)
+            if path.is_file()
+            else []
+        )
+    else:
+        records = usage_records_from_result_aggregate(result)
+
+    per_model: dict[str, ModelCost] = {}
+    for model, counts in records:
+        mc = per_model.setdefault(model, ModelCost(model=model))
+        mc.n_records += 1
+        mc.usage = mc.usage + counts
+
+    unpriced: list[str] = []
+    total: float | None = 0.0
+    for mc in per_model.values():
+        try:
+            bd = compute_cost(mc.model, mc.usage, table)
+        except UnknownModelPrice:
+            mc.unpriced = True
+            unpriced.append(mc.model)
+            continue
+        mc.cost_usd = bd.total_usd
+        mc.breakdown = {
+            "input_usd": bd.input_usd,
+            "output_usd": bd.output_usd,
+            "cache_read_usd": bd.cache_read_usd,
+            "cache_write_usd": bd.cache_write_usd,
+        }
+        total = (total or 0.0) + bd.total_usd
+    if unpriced or not per_model:
+        total = None if unpriced or not per_model else total
+
+    ar = result.get("agent_result") or {}
+    fm = result.get("final_metrics") or {}
+    recorded = fm.get("total_cost_usd", ar.get("cost_usd"))
+    return CostReport(
+        rollout_dir=str(rollout_dir),
+        source=kind,
+        source_path=str(path),
+        pricing_version=table.version,
+        n_records=len(records),
+        per_model=sorted(per_model.values(), key=lambda m: -(m.cost_usd or 0)),
+        total_cost_usd=total,
+        recorded_cost_usd=float(recorded)
+        if isinstance(recorded, int | float)
+        else None,
+        recorded_price_source=ar.get("price_source"),
+        recorded_usage_source=ar.get("usage_source")
+        or (result.get("usage_tracking") or {}).get("usage_source"),
+        unpriced_models=unpriced,
+        computed_at=datetime.now(UTC).isoformat(timespec="seconds"),
+    )
+
+
+def write_cost_report(
+    report: CostReport, rollout_dir: str | Path | None = None
+) -> Path:
+    out_dir = Path(rollout_dir or report.rollout_dir)
+    path = out_dir / "cost_recompute.json"
+    path.write_text(json.dumps(report.to_dict(), indent=2, default=str) + "\n")
+    return path
+
+
+def update_result_json(
+    report: CostReport, rollout_dir: str | Path | None = None
+) -> Path | None:
+    """Write the recomputed cost into ``result.json``; keep the old values."""
+    if report.total_cost_usd is None:
+        return None
+    path = Path(rollout_dir or report.rollout_dir) / "result.json"
+    result = _read_json(path)
+    if result is None:
+        return None
+    ar = result.setdefault("agent_result", {}) or {}
+    fm = result.setdefault("final_metrics", {}) or {}
+    history = list(ar.get("cost_history") or [])
+    history.append(
+        {
+            "cost_usd": ar.get("cost_usd", fm.get("total_cost_usd")),
+            "price_source": ar.get("price_source"),
+            "replaced_at": report.computed_at,
+        }
+    )
+    ar["cost_history"] = history
+    ar["cost_usd"] = report.total_cost_usd
+    ar["price_source"] = report.pricing_version
+    ar["cost_source"] = report.source
+    fm["total_cost_usd"] = report.total_cost_usd
+    result["agent_result"], result["final_metrics"] = ar, fm
+    path.write_text(json.dumps(result, indent=2, default=str) + "\n")
+    return path

--- a/src/benchflow/otel_capture.py
+++ b/src/benchflow/otel_capture.py
@@ -1,0 +1,267 @@
+"""Capture per-request token usage from Claude Code's OpenTelemetry export.
+
+In OAuth / subscription mode the agent (Claude Code via ``claude-agent-acp``)
+talks to the Anthropic API directly, so the LiteLLM proxy sees nothing and
+``llm_trajectory.jsonl`` is empty. Claude Code can, however, export telemetry:
+with ``CLAUDE_CODE_ENABLE_TELEMETRY=1`` and ``OTEL_LOGS_EXPORTER=otlp`` it emits
+one ``claude_code.api_request`` log record per Anthropic API call carrying
+``model``, ``input_tokens`` (uncached), ``output_tokens``, ``cache_read_tokens``,
+``cache_creation_tokens``, ``cost_usd`` (Claude Code's own list-price estimate),
+``duration_ms``, ``request_id`` and ``query_source`` (main / subagent / sdk …).
+Verified against Claude Code 2.1.263 on 2026-09-07 with the OTLP http/json
+protocol.
+
+:class:`OtelUsageReceiver` is a minimal OTLP/HTTP (JSON) endpoint that accepts
+``POST /v1/logs`` (and acknowledges ``/v1/metrics`` / ``/v1/traces``), extracts
+the ``api_request`` / ``api_error`` events and appends one JSON line per event to
+``trajectory/otel_usage.jsonl``. :func:`agent_env` returns the environment the
+agent container needs to send its telemetry there. :mod:`benchflow.cost` prices
+the file post hoc.
+
+Runtime capture is deliberately independent of Claude Code's ``cost_usd``: the
+tokens are the record, cost is derived from :mod:`benchflow.pricing`.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+import logging
+import threading
+from datetime import UTC, datetime
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+API_REQUEST_EVENT = "claude_code.api_request"
+API_ERROR_EVENT = "claude_code.api_error"
+_TOKEN_KEYS = (
+    "input_tokens",
+    "output_tokens",
+    "cache_read_tokens",
+    "cache_creation_tokens",
+)
+_COPY_KEYS = (
+    "model",
+    "cost_usd",
+    "duration_ms",
+    "request_id",
+    "client_request_id",
+    "query_source",
+    "effort",
+    "speed",
+    "session.id",
+    "prompt.id",
+    "event.sequence",
+    "event.timestamp",
+    "status_code",
+    "error",
+    "attempt",
+)
+
+
+def agent_env(
+    endpoint: str, *, metrics: bool = False, export_interval_ms: int = 1000
+) -> dict[str, str]:
+    """Environment variables that make Claude Code export usage to ``endpoint``.
+
+    ``endpoint`` is the receiver's base URL as seen from the agent, e.g.
+    ``http://host.docker.internal:4318``. Metrics are off by default (the log
+    events already carry every token count); turn them on for dashboards.
+    """
+    env = {
+        "CLAUDE_CODE_ENABLE_TELEMETRY": "1",
+        "OTEL_LOGS_EXPORTER": "otlp",
+        "OTEL_METRICS_EXPORTER": "otlp" if metrics else "none",
+        "OTEL_EXPORTER_OTLP_PROTOCOL": "http/json",
+        "OTEL_EXPORTER_OTLP_ENDPOINT": endpoint.rstrip("/"),
+        "OTEL_LOGS_EXPORT_INTERVAL": str(export_interval_ms),
+    }
+    if metrics:
+        env["OTEL_METRIC_EXPORT_INTERVAL"] = str(max(export_interval_ms, 1000))
+    return env
+
+
+def _attr_value(value: dict[str, Any]) -> Any:
+    """Unwrap an OTLP ``AnyValue`` (``{"stringValue": …}`` etc.)."""
+    if "stringValue" in value:
+        return value["stringValue"]
+    if "intValue" in value:
+        try:
+            return int(value["intValue"])
+        except (TypeError, ValueError):
+            return value["intValue"]
+    if "doubleValue" in value:
+        return value["doubleValue"]
+    if "boolValue" in value:
+        return bool(value["boolValue"])
+    if "arrayValue" in value:
+        return [_attr_value(v) for v in (value["arrayValue"] or {}).get("values", [])]
+    if "kvlistValue" in value:
+        return {
+            kv["key"]: _attr_value(kv["value"])
+            for kv in (value["kvlistValue"] or {}).get("values", [])
+        }
+    return value
+
+
+def _attrs(items: list[dict[str, Any]] | None) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for item in items or []:
+        key = item.get("key")
+        if isinstance(key, str) and isinstance(item.get("value"), dict):
+            out[key] = _attr_value(item["value"])
+    return out
+
+
+def _event_name(record: dict[str, Any], attrs: dict[str, Any]) -> str | None:
+    body = record.get("body")
+    if isinstance(body, dict) and isinstance(body.get("stringValue"), str):
+        return body["stringValue"]
+    name = record.get("eventName") or attrs.get("event.name")
+    if isinstance(name, str):
+        return name if name.startswith("claude_code.") else f"claude_code.{name}"
+    return None
+
+
+def parse_otlp_logs(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract usage records from an OTLP/JSON ``ExportLogsServiceRequest``."""
+    records: list[dict[str, Any]] = []
+    for rl in payload.get("resourceLogs", []) or []:
+        resource_attrs = _attrs((rl.get("resource") or {}).get("attributes"))
+        for sl in rl.get("scopeLogs", []) or []:
+            for lr in sl.get("logRecords", []) or []:
+                attrs = _attrs(lr.get("attributes"))
+                name = _event_name(lr, attrs)
+                if name not in (API_REQUEST_EVENT, API_ERROR_EVENT):
+                    continue
+                ts_ns = lr.get("timeUnixNano") or lr.get("observedTimeUnixNano")
+                try:
+                    ts = datetime.fromtimestamp(int(ts_ns) / 1e9, tz=UTC).isoformat(
+                        timespec="milliseconds"
+                    )
+                except (TypeError, ValueError):
+                    ts = attrs.get("event.timestamp")
+                rec: dict[str, Any] = {
+                    "event": name.removeprefix("claude_code."),
+                    "timestamp": ts,
+                }
+                for key in _TOKEN_KEYS:
+                    if key in attrs:
+                        try:
+                            rec[key] = int(attrs[key])
+                        except (TypeError, ValueError):
+                            rec[key] = 0
+                for key in _COPY_KEYS:
+                    if key in attrs:
+                        rec[key.replace(".", "_")] = attrs[key]
+                if "service.name" in resource_attrs:
+                    rec["service_name"] = resource_attrs["service.name"]
+                records.append(rec)
+    return records
+
+
+class OtelUsageReceiver:
+    """Threaded OTLP/HTTP JSON receiver writing ``otel_usage.jsonl``.
+
+    >>> rx = OtelUsageReceiver(out_path)          # doctest: +SKIP
+    >>> rx.start(); env = agent_env(rx.endpoint)   # doctest: +SKIP
+    >>> ...run the agent with env...; rx.stop()    # doctest: +SKIP
+    """
+
+    def __init__(
+        self, out_path: str | Path, *, host: str = "127.0.0.1", port: int = 0
+    ) -> None:
+        self.out_path = Path(out_path)
+        self.host, self._port = host, port
+        self._server: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+        self._lock = threading.Lock()
+        self.n_records = 0
+        self.n_requests = 0
+
+    # -- lifecycle
+    def start(self) -> OtelUsageReceiver:
+        self.out_path.parent.mkdir(parents=True, exist_ok=True)
+        receiver = self
+
+        class Handler(BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
+
+            def do_POST(self) -> None:
+                length = int(self.headers.get("Content-Length") or 0)
+                body = self.rfile.read(length) if length else b""
+                if self.headers.get("Content-Encoding", "").lower() == "gzip":
+                    try:
+                        body = gzip.decompress(body)
+                    except OSError:
+                        body = b""
+                receiver._handle(self.path, body, self.headers.get("Content-Type", ""))
+                out = b"{}"
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(out)))
+                self.end_headers()
+                self.wfile.write(out)
+
+            def log_message(self, format: str, *args: Any) -> None:  # stdlib signature
+                return  # silence default request logging
+
+        self._server = ThreadingHTTPServer((self.host, self._port), Handler)
+        self._server.daemon_threads = True
+        self._thread = threading.Thread(
+            target=self._server.serve_forever, name="otel-usage-receiver", daemon=True
+        )
+        self._thread.start()
+        return self
+
+    def stop(self) -> None:
+        if self._server is not None:
+            self._server.shutdown()
+            self._server.server_close()
+            self._server = None
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+            self._thread = None
+
+    def __enter__(self) -> OtelUsageReceiver:
+        return self.start()
+
+    def __exit__(self, *exc: Any) -> None:
+        self.stop()
+
+    @property
+    def port(self) -> int:
+        if self._server is None:
+            raise RuntimeError("receiver not started")
+        return int(self._server.server_address[1])
+
+    @property
+    def endpoint(self) -> str:
+        return f"http://{self.host}:{self.port}"
+
+    # -- ingestion
+    def _handle(self, path: str, body: bytes, content_type: str) -> None:
+        self.n_requests += 1
+        if not path.rstrip("/").endswith("/v1/logs"):
+            return  # metrics / traces are acknowledged and dropped
+        if "json" not in content_type.lower() and not body.lstrip().startswith(b"{"):
+            logger.warning(
+                "otel receiver: non-JSON logs payload (%s) ignored; use OTEL_EXPORTER_OTLP_PROTOCOL=http/json",
+                content_type,
+            )
+            return
+        try:
+            payload = json.loads(body.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            logger.warning("otel receiver: unparseable logs payload: %s", exc)
+            return
+        records = parse_otlp_logs(payload) if isinstance(payload, dict) else []
+        if not records:
+            return
+        with self._lock, self.out_path.open("a") as fh:
+            for rec in records:
+                fh.write(json.dumps(rec, sort_keys=True) + "\n")
+            self.n_records += len(records)

--- a/src/benchflow/pricing.py
+++ b/src/benchflow/pricing.py
@@ -1,0 +1,306 @@
+"""Official list prices per model and a post-hoc cost function.
+
+BenchFlow records *usage* (input / output / cache-read / cache-creation tokens)
+for every run mode and computes *cost* afterwards from this table, so a wrong or
+missing price never changes what was recorded and can always be re-applied.
+
+Prices are USD per million tokens (MTok). ``PRICING_VERSION`` stamps every cost
+figure derived from :data:`LIST_PRICES` so a later price change is traceable.
+
+Sources for the list table (checked 2026-09-07):
+- Anthropic first-party API list prices, cached model table 2026-06-24
+  (input / output). Cache read = 0.1 x input except Claude Fable 5.1 = $0.25/MTok;
+  cache write = 1.25 x input for the 5-minute TTL, 2 x input for the 1-hour TTL.
+- Claude Code's own ``modelUsage.costUSD`` (``costBasis: "list"``) on 2026-09-07
+  reproduces these numbers for ``claude-fable-5-1`` and ``claude-haiku-4-5``.
+
+:data:`LITELLM_OBSERVED_FP_2026_09` is NOT a list price. It is the effective
+price table LiteLLM applied in the FrontierPhysics 2026-08-30..09-04 run, fitted
+exactly (residual < 1e-14 relative) from the 538 recorded ``result.json``
+files. It exists so ``bench cost --pricing litellm-observed-fp-2026-09`` can
+reproduce the recorded ``total_cost_usd`` bit-for-bit, which is the regression
+check that the aggregation is right. Its cache-write price is 0.25 x input,
+i.e. one fifth of the official 1.25 x, which is the source of the gap between
+recorded cost and the real bill.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass
+from typing import Any
+
+PRICING_VERSION = "anthropic-list-2026-09-07"
+
+
+@dataclass(frozen=True)
+class ModelPrice:
+    """USD per million tokens for one model."""
+
+    input: float
+    output: float
+    cache_read: float
+    cache_write_5m: float
+    cache_write_1h: float
+
+    @classmethod
+    def anthropic(
+        cls,
+        input: float,
+        output: float,
+        *,
+        cache_read: float | None = None,
+        cache_write_5m: float | None = None,
+        cache_write_1h: float | None = None,
+    ) -> ModelPrice:
+        """Anthropic default ratios: read 0.1x, write 1.25x (5m) / 2x (1h)."""
+        return cls(
+            input=input,
+            output=output,
+            cache_read=input * 0.1 if cache_read is None else cache_read,
+            cache_write_5m=input * 1.25 if cache_write_5m is None else cache_write_5m,
+            cache_write_1h=input * 2.0 if cache_write_1h is None else cache_write_1h,
+        )
+
+
+@dataclass(frozen=True)
+class PriceTable:
+    version: str
+    prices: Mapping[str, ModelPrice]
+    note: str = ""
+
+    def get(self, model: str) -> ModelPrice | None:
+        key = canonical_model(model)
+        return self.prices.get(key) if key else None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "version": self.version,
+            "note": self.note,
+            "unit": "USD per 1M tokens",
+            "prices": {k: asdict(v) for k, v in self.prices.items()},
+        }
+
+
+LIST_PRICES = PriceTable(
+    version=PRICING_VERSION,
+    note="Anthropic first-party API list prices; cache read 0.1x (Fable 5.1: $0.25/MTok), "
+    "cache write 1.25x (5m TTL) / 2x (1h TTL).",
+    prices={
+        "claude-fable-5-1": ModelPrice.anthropic(10.0, 50.0, cache_read=0.25),
+        "claude-mythos-5-1": ModelPrice.anthropic(10.0, 50.0, cache_read=0.25),
+        "claude-fable-5": ModelPrice.anthropic(10.0, 50.0),
+        "claude-opus-5": ModelPrice.anthropic(5.0, 25.0),
+        "claude-opus-4-8": ModelPrice.anthropic(5.0, 25.0),
+        "claude-opus-4-7": ModelPrice.anthropic(5.0, 25.0),
+        "claude-opus-4-6": ModelPrice.anthropic(5.0, 25.0),
+        "claude-sonnet-5": ModelPrice.anthropic(2.0, 10.0),
+        "claude-sonnet-4-6": ModelPrice.anthropic(3.0, 15.0),
+        "claude-haiku-4-5": ModelPrice.anthropic(1.0, 5.0),
+    },
+)
+
+LITELLM_OBSERVED_FP_2026_09 = PriceTable(
+    version="litellm-observed-fp-2026-09",
+    note="Effective prices LiteLLM applied in the FrontierPhysics 2026-08-30..09-04 run, "
+    "fitted from 538 result.json files (exact). Cache write is 0.25x input, NOT the "
+    "official 1.25x. For reproduction of recorded cost only.",
+    prices={
+        "claude-fable-5": ModelPrice(10.0, 50.0, 1.0, 2.5, 2.5),
+        "claude-fable-5-1": ModelPrice(10.0, 50.0, 0.25, 2.5, 2.5),
+        "claude-opus-5": ModelPrice(5.0, 25.0, 0.5, 1.25, 1.25),
+    },
+)
+
+PRICE_TABLES: dict[str, PriceTable] = {
+    "list": LIST_PRICES,
+    LIST_PRICES.version: LIST_PRICES,
+    LITELLM_OBSERVED_FP_2026_09.version: LITELLM_OBSERVED_FP_2026_09,
+}
+
+
+def price_table(name: str | None) -> PriceTable:
+    if not name:
+        return LIST_PRICES
+    try:
+        return PRICE_TABLES[name]
+    except KeyError:
+        known = ", ".join(sorted(PRICE_TABLES))
+        raise KeyError(f"unknown price table {name!r}; known: {known}") from None
+
+
+_PROVIDER_PREFIX_RE = re.compile(
+    r"^(?:(?:anthropic|openrouter|bedrock|bedrock_converse|vertex_ai|azure_ai|databricks|"
+    r"deepinfra|perplexity)/)+",
+)
+_REGION_PREFIX_RE = re.compile(r"^(?:us|eu|global|jp|au|apac|us-gov)\.")
+_DATE_SUFFIX_RE = re.compile(r"-\d{8}$")
+_BEDROCK_VERSION_RE = re.compile(r"-v\d+(?::\d+)?$")
+_CONTEXT_SUFFIX_RE = re.compile(r"\[\w+\]$")
+
+
+def canonical_model(model: str | None) -> str | None:
+    """Reduce a provider-specific model id to the list-price key.
+
+    Handles LiteLLM route prefixes (``anthropic/…``), Bedrock ids
+    (``us.anthropic.claude-opus-5-v1:0``), Claude Code's context suffix
+    (``claude-opus-5[1m]``), dated snapshots (``claude-haiku-4-5-20251001``) and
+    dotted versions (``claude-fable-5.1``). Returns ``None`` for empty input.
+    """
+    if not model:
+        return None
+    m = model.strip().lower()
+    m = _PROVIDER_PREFIX_RE.sub("", m)
+    m = _REGION_PREFIX_RE.sub("", m)
+    m = m.removeprefix("anthropic.")
+    m = m.removeprefix("databricks-")
+    m = _CONTEXT_SUFFIX_RE.sub("", m)
+    m = _BEDROCK_VERSION_RE.sub("", m)
+    m = _DATE_SUFFIX_RE.sub("", m)
+    m = m.replace(".", "-")
+    return m or None
+
+
+@dataclass(frozen=True)
+class UsageCounts:
+    """Token counts in the Anthropic (additive) convention.
+
+    ``input_tokens`` is the UNCACHED input; cache reads and writes are separate
+    additive components. This is the shape of ``response.usage`` from the
+    Anthropic API and of Claude Code's telemetry. BenchFlow's normalized
+    ``n_input_tokens`` (cache-inclusive) must be converted with
+    :func:`from_inclusive_input` before pricing.
+    """
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_creation_tokens: int = 0
+    cache_creation_1h_tokens: int = 0  # subset of cache_creation_tokens
+
+    def __add__(self, other: UsageCounts) -> UsageCounts:
+        return UsageCounts(
+            self.input_tokens + other.input_tokens,
+            self.output_tokens + other.output_tokens,
+            self.cache_read_tokens + other.cache_read_tokens,
+            self.cache_creation_tokens + other.cache_creation_tokens,
+            self.cache_creation_1h_tokens + other.cache_creation_1h_tokens,
+        )
+
+    @property
+    def total_input_inclusive(self) -> int:
+        return self.input_tokens + self.cache_read_tokens + self.cache_creation_tokens
+
+    @classmethod
+    def from_inclusive_input(
+        cls,
+        *,
+        input_tokens_inclusive: int,
+        output_tokens: int,
+        cache_read_tokens: int,
+        cache_creation_tokens: int,
+        cache_creation_1h_tokens: int = 0,
+    ) -> UsageCounts:
+        """Build from BenchFlow's cache-inclusive ``n_input_tokens`` convention."""
+        uncached = input_tokens_inclusive - cache_read_tokens - cache_creation_tokens
+        return cls(
+            input_tokens=max(int(uncached), 0),
+            output_tokens=int(output_tokens),
+            cache_read_tokens=int(cache_read_tokens),
+            cache_creation_tokens=int(cache_creation_tokens),
+            cache_creation_1h_tokens=int(cache_creation_1h_tokens),
+        )
+
+    @classmethod
+    def from_anthropic_usage(cls, usage: Mapping[str, Any]) -> UsageCounts:
+        """From an Anthropic Messages ``usage`` block (also Claude Code transcripts)."""
+
+        def _i(*keys: str) -> int:
+            for k in keys:
+                v = usage.get(k)
+                if v is not None:
+                    try:
+                        return int(v)
+                    except (TypeError, ValueError):
+                        continue
+            return 0
+
+        cc = usage.get("cache_creation")
+        one_hour = 0
+        if isinstance(cc, Mapping):
+            try:
+                one_hour = int(cc.get("ephemeral_1h_input_tokens") or 0)
+            except (TypeError, ValueError):
+                one_hour = 0
+        return cls(
+            input_tokens=_i("input_tokens", "inputTokens"),
+            output_tokens=_i("output_tokens", "outputTokens"),
+            cache_read_tokens=_i(
+                "cache_read_input_tokens", "cache_read_tokens", "cacheReadInputTokens"
+            ),
+            cache_creation_tokens=_i(
+                "cache_creation_input_tokens",
+                "cache_creation_tokens",
+                "cacheCreationInputTokens",
+            ),
+            cache_creation_1h_tokens=one_hour,
+        )
+
+
+@dataclass(frozen=True)
+class CostBreakdown:
+    model: str
+    canonical_model: str
+    pricing_version: str
+    input_usd: float
+    output_usd: float
+    cache_read_usd: float
+    cache_write_usd: float
+
+    @property
+    def total_usd(self) -> float:
+        return (
+            self.input_usd
+            + self.output_usd
+            + self.cache_read_usd
+            + self.cache_write_usd
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        d["total_usd"] = self.total_usd
+        return d
+
+
+class UnknownModelPrice(KeyError):
+    """Raised when a model id has no entry in the selected price table."""
+
+
+def compute_cost(
+    model: str,
+    usage: UsageCounts,
+    table: PriceTable = LIST_PRICES,
+) -> CostBreakdown:
+    """Price one usage record. Raises :class:`UnknownModelPrice` if unpriced."""
+    price = table.get(model)
+    key = canonical_model(model)
+    if price is None or key is None:
+        raise UnknownModelPrice(
+            f"no price for model {model!r} (canonical {key!r}) in table {table.version}"
+        )
+    per = 1e-6
+    write_5m = usage.cache_creation_tokens - usage.cache_creation_1h_tokens
+    return CostBreakdown(
+        model=model,
+        canonical_model=key,
+        pricing_version=table.version,
+        input_usd=usage.input_tokens * price.input * per,
+        output_usd=usage.output_tokens * price.output * per,
+        cache_read_usd=usage.cache_read_tokens * price.cache_read * per,
+        cache_write_usd=(
+            max(write_5m, 0) * price.cache_write_5m
+            + usage.cache_creation_1h_tokens * price.cache_write_1h
+        )
+        * per,
+    )

--- a/tests/fixtures/otel/claude_code_logs.json
+++ b/tests/fixtures/otel/claude_code_logs.json
@@ -1,0 +1,598 @@
+{
+ "resourceLogs": [
+  {
+   "resource": {
+    "attributes": [
+     {
+      "key": "host.arch",
+      "value": {
+       "stringValue": "amd64"
+      }
+     },
+     {
+      "key": "os.type",
+      "value": {
+       "stringValue": "linux"
+      }
+     },
+     {
+      "key": "os.version",
+      "value": {
+       "stringValue": "7.0.0-1011-gcp"
+      }
+     },
+     {
+      "key": "service.name",
+      "value": {
+       "stringValue": "claude-code"
+      }
+     },
+     {
+      "key": "service.version",
+      "value": {
+       "stringValue": "2.1.263"
+      }
+     }
+    ],
+    "droppedAttributesCount": 0
+   },
+   "scopeLogs": [
+    {
+     "scope": {
+      "name": "com.anthropic.claude_code.events",
+      "version": "2.1.263"
+     },
+     "logRecords": [
+      {
+       "timeUnixNano": "1788803838212000000",
+       "observedTimeUnixNano": "1788803838212000000",
+       "body": {
+        "stringValue": "claude_code.user_prompt"
+       },
+       "attributes": [
+        {
+         "key": "user.id",
+         "value": {
+          "stringValue": "<user-id-redacted>"
+         }
+        },
+        {
+         "key": "session.id",
+         "value": {
+          "stringValue": "abfe0a1e-b5ad-49c9-9fcd-bebdd3b6f19c"
+         }
+        },
+        {
+         "key": "terminal.type",
+         "value": {
+          "stringValue": "tmux"
+         }
+        },
+        {
+         "key": "event.name",
+         "value": {
+          "stringValue": "user_prompt"
+         }
+        },
+        {
+         "key": "event.timestamp",
+         "value": {
+          "stringValue": "2026-09-07T17:57:18.212Z"
+         }
+        },
+        {
+         "key": "event.sequence",
+         "value": {
+          "intValue": 0
+         }
+        },
+        {
+         "key": "prompt.id",
+         "value": {
+          "stringValue": "b936dbdd-d9f8-47b7-9daa-5e366b24ea97"
+         }
+        },
+        {
+         "key": "prompt_length",
+         "value": {
+          "stringValue": "30"
+         }
+        },
+        {
+         "key": "prompt",
+         "value": {
+          "stringValue": "<REDACTED>"
+         }
+        },
+        {
+         "key": "message.uuid",
+         "value": {
+          "stringValue": "78584c0f-f4a0-4865-9276-ce5a8ceae2a0"
+         }
+        }
+       ],
+       "droppedAttributesCount": 0
+      },
+      {
+       "timeUnixNano": "1788803839149000000",
+       "observedTimeUnixNano": "1788803839149000000",
+       "body": {
+        "stringValue": "claude_code.api_request"
+       },
+       "attributes": [
+        {
+         "key": "user.id",
+         "value": {
+          "stringValue": "<user-id-redacted>"
+         }
+        },
+        {
+         "key": "session.id",
+         "value": {
+          "stringValue": "abfe0a1e-b5ad-49c9-9fcd-bebdd3b6f19c"
+         }
+        },
+        {
+         "key": "terminal.type",
+         "value": {
+          "stringValue": "tmux"
+         }
+        },
+        {
+         "key": "event.name",
+         "value": {
+          "stringValue": "api_request"
+         }
+        },
+        {
+         "key": "event.timestamp",
+         "value": {
+          "stringValue": "2026-09-07T17:57:19.149Z"
+         }
+        },
+        {
+         "key": "event.sequence",
+         "value": {
+          "intValue": 1
+         }
+        },
+        {
+         "key": "prompt.id",
+         "value": {
+          "stringValue": "b936dbdd-d9f8-47b7-9daa-5e366b24ea97"
+         }
+        },
+        {
+         "key": "model",
+         "value": {
+          "stringValue": "claude-haiku-4-5-20251001"
+         }
+        },
+        {
+         "key": "input_tokens",
+         "value": {
+          "intValue": 899
+         }
+        },
+        {
+         "key": "output_tokens",
+         "value": {
+          "intValue": 8
+         }
+        },
+        {
+         "key": "cache_read_tokens",
+         "value": {
+          "intValue": 0
+         }
+        },
+        {
+         "key": "cache_creation_tokens",
+         "value": {
+          "intValue": 0
+         }
+        },
+        {
+         "key": "cost_usd",
+         "value": {
+          "doubleValue": 0.000939
+         }
+        },
+        {
+         "key": "cost_usd_micros",
+         "value": {
+          "intValue": 939
+         }
+        },
+        {
+         "key": "duration_ms",
+         "value": {
+          "intValue": 654
+         }
+        },
+        {
+         "key": "request_id",
+         "value": {
+          "stringValue": "req_011CepWcwJDNQuSAPGt3r84K"
+         }
+        },
+        {
+         "key": "client_request_id",
+         "value": {
+          "stringValue": "1a03395c-a2df-4894-bc50-5fad75660fcb"
+         }
+        },
+        {
+         "key": "speed",
+         "value": {
+          "stringValue": "normal"
+         }
+        },
+        {
+         "key": "query_source",
+         "value": {
+          "stringValue": "generate_session_title"
+         }
+        }
+       ],
+       "droppedAttributesCount": 0
+      },
+      {
+       "timeUnixNano": "1788803839149000000",
+       "observedTimeUnixNano": "1788803839149000000",
+       "body": {
+        "stringValue": "claude_code.assistant_response"
+       },
+       "attributes": [
+        {
+         "key": "user.id",
+         "value": {
+          "stringValue": "<user-id-redacted>"
+         }
+        },
+        {
+         "key": "session.id",
+         "value": {
+          "stringValue": "abfe0a1e-b5ad-49c9-9fcd-bebdd3b6f19c"
+         }
+        },
+        {
+         "key": "terminal.type",
+         "value": {
+          "stringValue": "tmux"
+         }
+        },
+        {
+         "key": "event.name",
+         "value": {
+          "stringValue": "assistant_response"
+         }
+        },
+        {
+         "key": "event.timestamp",
+         "value": {
+          "stringValue": "2026-09-07T17:57:19.149Z"
+         }
+        },
+        {
+         "key": "event.sequence",
+         "value": {
+          "intValue": 2
+         }
+        },
+        {
+         "key": "prompt.id",
+         "value": {
+          "stringValue": "b936dbdd-d9f8-47b7-9daa-5e366b24ea97"
+         }
+        },
+        {
+         "key": "response_length",
+         "value": {
+          "intValue": 14
+         }
+        },
+        {
+         "key": "response",
+         "value": {
+          "stringValue": "<REDACTED>"
+         }
+        },
+        {
+         "key": "request_id",
+         "value": {
+          "stringValue": "req_011CepWcwJDNQuSAPGt3r84K"
+         }
+        },
+        {
+         "key": "message.uuid",
+         "value": {
+          "stringValue": "6cf0b0a9-97ca-42d9-9549-b7a8bd7b56d9"
+         }
+        },
+        {
+         "key": "model",
+         "value": {
+          "stringValue": "claude-haiku-4-5-20251001"
+         }
+        },
+        {
+         "key": "query_source",
+         "value": {
+          "stringValue": "generate_session_title"
+         }
+        }
+       ],
+       "droppedAttributesCount": 0
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "resource": {
+    "attributes": [
+     {
+      "key": "host.arch",
+      "value": {
+       "stringValue": "amd64"
+      }
+     },
+     {
+      "key": "os.type",
+      "value": {
+       "stringValue": "linux"
+      }
+     },
+     {
+      "key": "os.version",
+      "value": {
+       "stringValue": "7.0.0-1011-gcp"
+      }
+     },
+     {
+      "key": "service.name",
+      "value": {
+       "stringValue": "claude-code"
+      }
+     },
+     {
+      "key": "service.version",
+      "value": {
+       "stringValue": "2.1.263"
+      }
+     }
+    ],
+    "droppedAttributesCount": 0
+   },
+   "scopeLogs": [
+    {
+     "scope": {
+      "name": "com.anthropic.claude_code.events",
+      "version": "2.1.263"
+     },
+     "logRecords": [
+      {
+       "timeUnixNano": "1788803842162000000",
+       "observedTimeUnixNano": "1788803842162000000",
+       "body": {
+        "stringValue": "claude_code.api_request"
+       },
+       "attributes": [
+        {
+         "key": "user.id",
+         "value": {
+          "stringValue": "<user-id-redacted>"
+         }
+        },
+        {
+         "key": "session.id",
+         "value": {
+          "stringValue": "abfe0a1e-b5ad-49c9-9fcd-bebdd3b6f19c"
+         }
+        },
+        {
+         "key": "terminal.type",
+         "value": {
+          "stringValue": "tmux"
+         }
+        },
+        {
+         "key": "event.name",
+         "value": {
+          "stringValue": "api_request"
+         }
+        },
+        {
+         "key": "event.timestamp",
+         "value": {
+          "stringValue": "2026-09-07T17:57:22.162Z"
+         }
+        },
+        {
+         "key": "event.sequence",
+         "value": {
+          "intValue": 3
+         }
+        },
+        {
+         "key": "prompt.id",
+         "value": {
+          "stringValue": "b936dbdd-d9f8-47b7-9daa-5e366b24ea97"
+         }
+        },
+        {
+         "key": "model",
+         "value": {
+          "stringValue": "claude-fable-5-1"
+         }
+        },
+        {
+         "key": "input_tokens",
+         "value": {
+          "intValue": 2
+         }
+        },
+        {
+         "key": "output_tokens",
+         "value": {
+          "intValue": 4
+         }
+        },
+        {
+         "key": "cache_read_tokens",
+         "value": {
+          "intValue": 16602
+         }
+        },
+        {
+         "key": "cache_creation_tokens",
+         "value": {
+          "intValue": 0
+         }
+        },
+        {
+         "key": "cost_usd",
+         "value": {
+          "doubleValue": 0.004370499999999999
+         }
+        },
+        {
+         "key": "cost_usd_micros",
+         "value": {
+          "intValue": 4370
+         }
+        },
+        {
+         "key": "duration_ms",
+         "value": {
+          "intValue": 3667
+         }
+        },
+        {
+         "key": "request_id",
+         "value": {
+          "stringValue": "req_011CepWcwPRRJ3bYZjLNT3tR"
+         }
+        },
+        {
+         "key": "client_request_id",
+         "value": {
+          "stringValue": "3bfffd87-4327-4c5a-ad71-bf793a917e1f"
+         }
+        },
+        {
+         "key": "speed",
+         "value": {
+          "stringValue": "normal"
+         }
+        },
+        {
+         "key": "query_source",
+         "value": {
+          "stringValue": "sdk"
+         }
+        },
+        {
+         "key": "effort",
+         "value": {
+          "stringValue": "high"
+         }
+        }
+       ],
+       "droppedAttributesCount": 0
+      },
+      {
+       "timeUnixNano": "1788803842162000000",
+       "observedTimeUnixNano": "1788803842162000000",
+       "body": {
+        "stringValue": "claude_code.assistant_response"
+       },
+       "attributes": [
+        {
+         "key": "user.id",
+         "value": {
+          "stringValue": "<user-id-redacted>"
+         }
+        },
+        {
+         "key": "session.id",
+         "value": {
+          "stringValue": "abfe0a1e-b5ad-49c9-9fcd-bebdd3b6f19c"
+         }
+        },
+        {
+         "key": "terminal.type",
+         "value": {
+          "stringValue": "tmux"
+         }
+        },
+        {
+         "key": "event.name",
+         "value": {
+          "stringValue": "assistant_response"
+         }
+        },
+        {
+         "key": "event.timestamp",
+         "value": {
+          "stringValue": "2026-09-07T17:57:22.162Z"
+         }
+        },
+        {
+         "key": "event.sequence",
+         "value": {
+          "intValue": 4
+         }
+        },
+        {
+         "key": "prompt.id",
+         "value": {
+          "stringValue": "b936dbdd-d9f8-47b7-9daa-5e366b24ea97"
+         }
+        },
+        {
+         "key": "response_length",
+         "value": {
+          "intValue": 2
+         }
+        },
+        {
+         "key": "response",
+         "value": {
+          "stringValue": "<REDACTED>"
+         }
+        },
+        {
+         "key": "request_id",
+         "value": {
+          "stringValue": "req_011CepWcwPRRJ3bYZjLNT3tR"
+         }
+        },
+        {
+         "key": "message.uuid",
+         "value": {
+          "stringValue": "0e6eabed-b3ee-4cb3-9e96-928e449710f5"
+         }
+        },
+        {
+         "key": "model",
+         "value": {
+          "stringValue": "claude-fable-5-1"
+         }
+        },
+        {
+         "key": "query_source",
+         "value": {
+          "stringValue": "sdk"
+         }
+        }
+       ],
+       "droppedAttributesCount": 0
+      }
+     ]
+    }
+   ]
+  }
+ ]
+}

--- a/tests/fixtures/otel/claude_code_metrics.json
+++ b/tests/fixtures/otel/claude_code_metrics.json
@@ -1,0 +1,324 @@
+{
+ "resourceMetrics": [
+  {
+   "resource": {
+    "attributes": [
+     {
+      "key": "host.arch",
+      "value": {
+       "stringValue": "amd64"
+      }
+     },
+     {
+      "key": "os.type",
+      "value": {
+       "stringValue": "linux"
+      }
+     },
+     {
+      "key": "os.version",
+      "value": {
+       "stringValue": "7.0.0-1011-gcp"
+      }
+     },
+     {
+      "key": "service.name",
+      "value": {
+       "stringValue": "claude-code"
+      }
+     },
+     {
+      "key": "service.version",
+      "value": {
+       "stringValue": "2.1.263"
+      }
+     }
+    ],
+    "droppedAttributesCount": 0
+   },
+   "scopeMetrics": [
+    {
+     "scope": {
+      "name": "com.anthropic.claude_code",
+      "version": "2.1.263"
+     },
+     "metrics": [
+      {
+       "name": "claude_code.session.count",
+       "description": "Count of CLI sessions started",
+       "unit": "",
+       "sum": {
+        "aggregationTemporality": 1,
+        "isMonotonic": true,
+        "dataPoints": [
+         {
+          "attributes": [
+           {
+            "key": "user.id",
+            "value": {
+             "stringValue": "<user-id-redacted>"
+            }
+           },
+           {
+            "key": "session.id",
+            "value": {
+             "stringValue": "abfe0a1e-b5ad-49c9-9fcd-bebdd3b6f19c"
+            }
+           },
+           {
+            "key": "terminal.type",
+            "value": {
+             "stringValue": "tmux"
+            }
+           },
+           {
+            "key": "start_type",
+            "value": {
+             "stringValue": "fresh"
+            }
+           }
+          ],
+          "startTimeUnixNano": "1788803838118000000",
+          "timeUnixNano": "1788803840107000000",
+          "asDouble": 1
+         }
+        ]
+       }
+      },
+      {
+       "name": "claude_code.cost.usage",
+       "description": "Cost of the Claude Code session",
+       "unit": "USD",
+       "sum": {
+        "aggregationTemporality": 1,
+        "isMonotonic": true,
+        "dataPoints": [
+         {
+          "attributes": [
+           {
+            "key": "user.id",
+            "value": {
+             "stringValue": "<user-id-redacted>"
+            }
+           },
+           {
+            "key": "session.id",
+            "value": {
+             "stringValue": "abfe0a1e-b5ad-49c9-9fcd-bebdd3b6f19c"
+            }
+           },
+           {
+            "key": "terminal.type",
+            "value": {
+             "stringValue": "tmux"
+            }
+           },
+           {
+            "key": "model",
+            "value": {
+             "stringValue": "claude-haiku-4-5-20251001"
+            }
+           },
+           {
+            "key": "query_source",
+            "value": {
+             "stringValue": "auxiliary"
+            }
+           }
+          ],
+          "startTimeUnixNano": "1788803839146000000",
+          "timeUnixNano": "1788803840107000000",
+          "asDouble": 0.000939
+         }
+        ]
+       }
+      },
+      {
+       "name": "claude_code.token.usage",
+       "description": "Number of tokens used",
+       "unit": "tokens",
+       "sum": {
+        "aggregationTemporality": 1,
+        "isMonotonic": true,
+        "dataPoints": [
+         {
+          "attributes": [
+           {
+            "key": "user.id",
+            "value": {
+             "stringValue": "<user-id-redacted>"
+            }
+           },
+           {
+            "key": "session.id",
+            "value": {
+             "stringValue": "abfe0a1e-b5ad-49c9-9fcd-bebdd3b6f19c"
+            }
+           },
+           {
+            "key": "terminal.type",
+            "value": {
+             "stringValue": "tmux"
+            }
+           },
+           {
+            "key": "model",
+            "value": {
+             "stringValue": "claude-haiku-4-5-20251001"
+            }
+           },
+           {
+            "key": "query_source",
+            "value": {
+             "stringValue": "auxiliary"
+            }
+           },
+           {
+            "key": "type",
+            "value": {
+             "stringValue": "input"
+            }
+           }
+          ],
+          "startTimeUnixNano": "1788803839146000000",
+          "timeUnixNano": "1788803840107000000",
+          "asDouble": 899
+         },
+         {
+          "attributes": [
+           {
+            "key": "user.id",
+            "value": {
+             "stringValue": "<user-id-redacted>"
+            }
+           },
+           {
+            "key": "session.id",
+            "value": {
+             "stringValue": "abfe0a1e-b5ad-49c9-9fcd-bebdd3b6f19c"
+            }
+           },
+           {
+            "key": "terminal.type",
+            "value": {
+             "stringValue": "tmux"
+            }
+           },
+           {
+            "key": "model",
+            "value": {
+             "stringValue": "claude-haiku-4-5-20251001"
+            }
+           },
+           {
+            "key": "query_source",
+            "value": {
+             "stringValue": "auxiliary"
+            }
+           },
+           {
+            "key": "type",
+            "value": {
+             "stringValue": "output"
+            }
+           }
+          ],
+          "startTimeUnixNano": "1788803839146000000",
+          "timeUnixNano": "1788803840107000000",
+          "asDouble": 8
+         },
+         {
+          "attributes": [
+           {
+            "key": "user.id",
+            "value": {
+             "stringValue": "<user-id-redacted>"
+            }
+           },
+           {
+            "key": "session.id",
+            "value": {
+             "stringValue": "abfe0a1e-b5ad-49c9-9fcd-bebdd3b6f19c"
+            }
+           },
+           {
+            "key": "terminal.type",
+            "value": {
+             "stringValue": "tmux"
+            }
+           },
+           {
+            "key": "model",
+            "value": {
+             "stringValue": "claude-haiku-4-5-20251001"
+            }
+           },
+           {
+            "key": "query_source",
+            "value": {
+             "stringValue": "auxiliary"
+            }
+           },
+           {
+            "key": "type",
+            "value": {
+             "stringValue": "cacheRead"
+            }
+           }
+          ],
+          "startTimeUnixNano": "1788803839147000000",
+          "timeUnixNano": "1788803840107000000",
+          "asDouble": 0
+         },
+         {
+          "attributes": [
+           {
+            "key": "user.id",
+            "value": {
+             "stringValue": "<user-id-redacted>"
+            }
+           },
+           {
+            "key": "session.id",
+            "value": {
+             "stringValue": "abfe0a1e-b5ad-49c9-9fcd-bebdd3b6f19c"
+            }
+           },
+           {
+            "key": "terminal.type",
+            "value": {
+             "stringValue": "tmux"
+            }
+           },
+           {
+            "key": "model",
+            "value": {
+             "stringValue": "claude-haiku-4-5-20251001"
+            }
+           },
+           {
+            "key": "query_source",
+            "value": {
+             "stringValue": "auxiliary"
+            }
+           },
+           {
+            "key": "type",
+            "value": {
+             "stringValue": "cacheCreation"
+            }
+           }
+          ],
+          "startTimeUnixNano": "1788803839147000000",
+          "timeUnixNano": "1788803840107000000",
+          "asDouble": 0
+         }
+        ]
+       }
+      }
+     ]
+    }
+   ]
+  }
+ ]
+}

--- a/tests/test_otel_capture.py
+++ b/tests/test_otel_capture.py
@@ -1,0 +1,150 @@
+"""Tests for benchflow.otel_capture (Claude Code OTLP usage receiver)."""
+
+from __future__ import annotations
+
+import gzip
+import json
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+from benchflow.cost import recompute_rollout_cost
+from benchflow.otel_capture import OtelUsageReceiver, agent_env, parse_otlp_logs
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "otel"
+LOGS_FIXTURE = FIXTURE_DIR / "claude_code_logs.json"
+METRICS_FIXTURE = FIXTURE_DIR / "claude_code_metrics.json"
+
+
+def _post(url: str, body: bytes, *, gzip_body: bool = False) -> int:
+    headers = {"Content-Type": "application/json"}
+    if gzip_body:
+        body = gzip.compress(body)
+        headers["Content-Encoding"] = "gzip"
+    req = urllib.request.Request(url, data=body, headers=headers, method="POST")
+    with urllib.request.urlopen(req, timeout=5) as resp:
+        return resp.status
+
+
+def test_parse_otlp_logs_real_claude_code_payload():
+    """Fixture captured from Claude Code 2.1.263 (2026-09-07) with OTEL_EXPORTER_OTLP_PROTOCOL=http/json."""
+    payload = json.loads(LOGS_FIXTURE.read_text())
+    records = parse_otlp_logs(payload)
+    # 5 log records in the payload; only the two api_request events are usage
+    assert [r["event"] for r in records] == ["api_request", "api_request"]
+    haiku, fable = records
+    assert haiku["model"] == "claude-haiku-4-5-20251001"
+    assert (
+        haiku["input_tokens"],
+        haiku["output_tokens"],
+        haiku["cache_read_tokens"],
+        haiku["cache_creation_tokens"],
+    ) == (899, 8, 0, 0)
+    assert haiku["query_source"] == "generate_session_title"
+    assert fable["model"] == "claude-fable-5-1"
+    assert (
+        fable["input_tokens"],
+        fable["output_tokens"],
+        fable["cache_read_tokens"],
+        fable["cache_creation_tokens"],
+    ) == (2, 4, 16602, 0)
+    assert fable["cost_usd"] == pytest.approx(0.0043705)
+    assert fable["duration_ms"] == 3667
+    assert fable["request_id"].startswith("req_")
+    assert fable["effort"] == "high"
+    assert fable["timestamp"].startswith("2026-09-07T17:57:22")
+    assert fable["session_id"] == haiku["session_id"]
+
+
+def test_parse_otlp_logs_ignores_other_events_and_empty():
+    assert parse_otlp_logs({}) == []
+    payload = {
+        "resourceLogs": [
+            {
+                "scopeLogs": [
+                    {
+                        "logRecords": [
+                            {
+                                "body": {"stringValue": "claude_code.tool_result"},
+                                "attributes": [
+                                    {
+                                        "key": "tool_name",
+                                        "value": {"stringValue": "Bash"},
+                                    }
+                                ],
+                            },
+                            {
+                                "attributes": [
+                                    {
+                                        "key": "event.name",
+                                        "value": {"stringValue": "api_error"},
+                                    },
+                                    {
+                                        "key": "model",
+                                        "value": {"stringValue": "claude-opus-5"},
+                                    },
+                                    {
+                                        "key": "status_code",
+                                        "value": {"intValue": "529"},
+                                    },
+                                ]
+                            },
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+    records = parse_otlp_logs(payload)
+    assert len(records) == 1
+    assert records[0]["event"] == "api_error" and records[0]["status_code"] == 529
+
+
+def test_agent_env_points_at_receiver():
+    env = agent_env("http://host.docker.internal:4318/")
+    assert env["CLAUDE_CODE_ENABLE_TELEMETRY"] == "1"
+    assert env["OTEL_LOGS_EXPORTER"] == "otlp"
+    assert env["OTEL_METRICS_EXPORTER"] == "none"
+    assert env["OTEL_EXPORTER_OTLP_PROTOCOL"] == "http/json"
+    assert env["OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://host.docker.internal:4318"
+    assert agent_env("http://x", metrics=True)["OTEL_METRICS_EXPORTER"] == "otlp"
+
+
+def test_receiver_writes_usage_jsonl_and_cost_recompute_reads_it(tmp_path):
+    rollout = tmp_path / "rollout"
+    (rollout / "trajectory").mkdir(parents=True)
+    (rollout / "result.json").write_text(
+        json.dumps(
+            {
+                "model": "claude-fable-5-1",
+                "agent_result": {"usage_source": "agent_native_acp"},
+                "final_metrics": {},
+            }
+        )
+    )
+    out = rollout / "trajectory" / "otel_usage.jsonl"
+    logs = LOGS_FIXTURE.read_bytes()
+    metrics = METRICS_FIXTURE.read_bytes()
+
+    with OtelUsageReceiver(out) as rx:
+        env = agent_env(rx.endpoint)
+        base = env["OTEL_EXPORTER_OTLP_ENDPOINT"]
+        assert _post(f"{base}/v1/logs", logs) == 200
+        assert _post(f"{base}/v1/metrics", metrics) == 200  # acknowledged, not recorded
+        assert _post(f"{base}/v1/logs", logs, gzip_body=True) == 200  # gzip accepted
+        assert rx.n_requests == 3
+    assert rx.n_records == 4
+
+    lines = [json.loads(line) for line in out.read_text().splitlines()]
+    assert len(lines) == 4
+    assert all(line["event"] == "api_request" for line in lines)
+
+    report = recompute_rollout_cost(rollout)
+    assert report.source == "otel_usage"
+    # the second (gzip) post repeated the same request_ids -> deduped to 2 records
+    assert report.n_records == 2
+    by_model = {m.model: m.cost_usd for m in report.per_model}
+    assert by_model["claude-fable-5-1"] == pytest.approx(0.0043705, abs=1e-6)
+    assert by_model["claude-haiku-4-5-20251001"] == pytest.approx(0.000939, abs=1e-6)
+    assert report.total_cost_usd == pytest.approx(0.0043705 + 0.000939, abs=2e-6)

--- a/tests/test_pricing_cost.py
+++ b/tests/test_pricing_cost.py
@@ -1,0 +1,467 @@
+"""Tests for benchflow.pricing and benchflow.cost (post-hoc cost recomputation)."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from benchflow.cost import (
+    recompute_rollout_cost,
+    update_result_json,
+    usage_records_from_llm_trajectory,
+    write_cost_report,
+)
+from benchflow.pricing import (
+    LIST_PRICES,
+    LITELLM_OBSERVED_FP_2026_09,
+    PRICING_VERSION,
+    UnknownModelPrice,
+    UsageCounts,
+    canonical_model,
+    compute_cost,
+    price_table,
+)
+from benchflow.trajectories.types import (
+    LLMExchange,
+    LLMRequest,
+    LLMResponse,
+    Trajectory,
+)
+
+MTOK = 1_000_000
+
+
+# ------------------------------------------------------------------ pricing
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("claude-fable-5-1", "claude-fable-5-1"),
+        ("anthropic/claude-fable-5-1", "claude-fable-5-1"),
+        ("openrouter/anthropic/claude-fable-5.1", "claude-fable-5-1"),
+        ("us.anthropic.claude-opus-5-v1:0", "claude-opus-5"),
+        ("global.anthropic.claude-fable-5", "claude-fable-5"),
+        ("claude-opus-5[1m]", "claude-opus-5"),
+        ("claude-haiku-4-5-20251001", "claude-haiku-4-5"),
+        ("databricks/databricks-claude-sonnet-5", "claude-sonnet-5"),
+        ("", None),
+        (None, None),
+    ],
+)
+def test_canonical_model(raw, expected):
+    assert canonical_model(raw) == expected
+
+
+def test_list_prices_are_anthropic_ratios():
+    p = LIST_PRICES.get("claude-opus-5")
+    assert p is not None
+    assert (p.input, p.output, p.cache_read, p.cache_write_5m, p.cache_write_1h) == (
+        5.0,
+        25.0,
+        0.5,
+        6.25,
+        10.0,
+    )
+    fable = LIST_PRICES.get("claude-fable-5-1")
+    assert fable is not None
+    assert fable.cache_read == 0.25  # Fable 5.1 special cache-read price
+    assert fable.cache_write_5m == 12.5
+
+
+def test_compute_cost_breakdown_and_1h_cache():
+    usage = UsageCounts(
+        input_tokens=1 * MTOK,
+        output_tokens=2 * MTOK,
+        cache_read_tokens=10 * MTOK,
+        cache_creation_tokens=4 * MTOK,
+        cache_creation_1h_tokens=1 * MTOK,  # 1 of the 4 written with the 1h TTL
+    )
+    bd = compute_cost("claude-opus-5", usage)
+    assert bd.pricing_version == PRICING_VERSION
+    assert bd.input_usd == pytest.approx(5.0)
+    assert bd.output_usd == pytest.approx(50.0)
+    assert bd.cache_read_usd == pytest.approx(5.0)
+    assert bd.cache_write_usd == pytest.approx(3 * 6.25 + 1 * 10.0)
+    assert bd.total_usd == pytest.approx(5 + 50 + 5 + 28.75)
+
+
+def test_compute_cost_unknown_model_raises():
+    with pytest.raises(UnknownModelPrice):
+        compute_cost("gpt-99", UsageCounts(input_tokens=10))
+
+
+def test_price_table_lookup():
+    assert price_table(None) is LIST_PRICES
+    assert price_table("list") is LIST_PRICES
+    assert (
+        price_table(LITELLM_OBSERVED_FP_2026_09.version) is LITELLM_OBSERVED_FP_2026_09
+    )
+    with pytest.raises(KeyError):
+        price_table("nope")
+
+
+def test_usage_from_inclusive_input_matches_benchflow_normalization():
+    # BenchFlow's n_input_tokens = uncached + cache_read + cache_creation
+    u = UsageCounts.from_inclusive_input(
+        input_tokens_inclusive=63_728_808,
+        output_tokens=424_304,
+        cache_read_tokens=41_121_406,
+        cache_creation_tokens=11_190_144,
+    )
+    assert u.input_tokens == 63_728_808 - 41_121_406 - 11_190_144
+    assert u.total_input_inclusive == 63_728_808
+
+
+def test_usage_from_anthropic_usage_block():
+    u = UsageCounts.from_anthropic_usage(
+        {
+            "input_tokens": 2,
+            "output_tokens": 219,
+            "cache_read_input_tokens": 24614,
+            "cache_creation_input_tokens": 7366,
+            "cache_creation": {
+                "ephemeral_1h_input_tokens": 366,
+                "ephemeral_5m_input_tokens": 7000,
+            },
+        }
+    )
+    assert (
+        u.input_tokens,
+        u.output_tokens,
+        u.cache_read_tokens,
+        u.cache_creation_tokens,
+    ) == (2, 219, 24614, 7366)
+    assert u.cache_creation_1h_tokens == 366
+
+
+# ------------------------------------------------------------------ fixtures
+
+
+def _anthropic_exchange(
+    model: str, usage: dict, *, provider_model: str | None = None
+) -> LLMExchange:
+    return LLMExchange(
+        request=LLMRequest(
+            timestamp=datetime(2026, 9, 1, 12, 0, 0),
+            path="/v1/messages",
+            body={"model": model, "messages": []},
+        ),
+        response=LLMResponse(
+            timestamp=datetime(2026, 9, 1, 12, 0, 5),
+            status_code=200,
+            body={"model": model, "usage": usage, "content": []},
+        ),
+        duration_ms=5000.0,
+        metadata={"provider_model": provider_model or model, "request_model": model},
+    )
+
+
+def _write_rollout(
+    tmp_path: Path,
+    *,
+    model: str,
+    exchanges: list[LLMExchange] | None = None,
+    result: dict | None = None,
+) -> Path:
+    rollout = tmp_path / "rollout"
+    (rollout / "trajectory").mkdir(parents=True)
+    if exchanges is not None:
+        traj = Trajectory(
+            session_id="s", agent_name="claude-agent-acp", exchanges=exchanges
+        )
+        (rollout / "trajectory" / "llm_trajectory.jsonl").write_text(
+            traj.to_jsonl() + "\n"
+        )
+    base = {
+        "task_name": "t",
+        "rollout_name": "t__1",
+        "model": model,
+        "agent_result": {
+            "usage_source": "provider_response",
+            "price_source": "litellm",
+            "cost_usd": 1.0,
+        },
+        "final_metrics": {"total_cost_usd": 1.0},
+    }
+    if result:
+        base.update(result)
+    (rollout / "result.json").write_text(json.dumps(base))
+    return rollout
+
+
+# ------------------------------------------------------------------ llm_trajectory
+
+
+def test_recompute_from_llm_trajectory_anthropic_usage(tmp_path):
+    exchanges = [
+        _anthropic_exchange(
+            "anthropic/claude-opus-5",
+            {
+                "input_tokens": 1000,
+                "output_tokens": 100,
+                "cache_read_input_tokens": 5000,
+                "cache_creation_input_tokens": 2000,
+            },
+        ),
+        _anthropic_exchange(
+            "anthropic/claude-opus-5",
+            {
+                "input_tokens": 500,
+                "output_tokens": 50,
+                "cache_read_input_tokens": 7000,
+                "cache_creation_input_tokens": 0,
+            },
+        ),
+    ]
+    # a failed call without usage must not be counted
+    failed = _anthropic_exchange("anthropic/claude-opus-5", {})
+    failed.response.status_code = 529
+    failed.response.body = {"error": {"message": "overloaded"}}
+    rollout = _write_rollout(
+        tmp_path, model="claude-opus-5", exchanges=[*exchanges, failed]
+    )
+
+    report = recompute_rollout_cost(rollout)
+    assert report.source == "llm_trajectory"
+    assert report.n_records == 2
+    assert len(report.per_model) == 1
+    m = report.per_model[0]
+    assert m.usage == UsageCounts(1500, 150, 12000, 2000)
+    expected = (1500 * 5 + 150 * 25 + 12000 * 0.5 + 2000 * 6.25) / MTOK
+    assert report.total_cost_usd == pytest.approx(expected)
+    assert report.recorded_cost_usd == 1.0
+    assert report.delta_usd == pytest.approx(expected - 1.0)
+
+
+def test_recompute_from_llm_trajectory_openai_style_usage(tmp_path):
+    # OpenAI convention: prompt_tokens is cache-INCLUSIVE; cached_tokens is a subset.
+    ex = LLMExchange(
+        request=LLMRequest(body={"model": "gpt-x", "messages": []}),
+        response=LLMResponse(
+            body={
+                "model": "claude-sonnet-5",  # priced model id on the response
+                "usage": {
+                    "prompt_tokens": 1000,
+                    "completion_tokens": 10,
+                    "prompt_tokens_details": {"cached_tokens": 600},
+                },
+            }
+        ),
+        metadata={"provider_model": "claude-sonnet-5"},
+    )
+    rollout = _write_rollout(tmp_path, model="claude-sonnet-5", exchanges=[ex])
+    records = usage_records_from_llm_trajectory(
+        rollout / "trajectory" / "llm_trajectory.jsonl"
+    )
+    assert records == [("claude-sonnet-5", UsageCounts(400, 10, 600, 0))]
+
+
+def test_recompute_unpriced_model_reports_none(tmp_path):
+    ex = _anthropic_exchange(
+        "some-vendor/mystery-model", {"input_tokens": 10, "output_tokens": 1}
+    )
+    rollout = _write_rollout(tmp_path, model="mystery-model", exchanges=[ex])
+    report = recompute_rollout_cost(rollout)
+    assert report.total_cost_usd is None
+    assert report.unpriced_models == ["some-vendor/mystery-model"]
+    assert report.per_model[0].unpriced is True
+
+
+# ------------------------------------------------------------------ otel_usage (OAuth capture)
+
+
+def test_recompute_from_otel_usage_dedupes_request_ids(tmp_path):
+    rollout = _write_rollout(tmp_path, model="claude-fable-5-1")
+    rows = [
+        {
+            "event": "api_request",
+            "model": "claude-fable-5-1",
+            "input_tokens": 2,
+            "output_tokens": 4,
+            "cache_read_tokens": 16602,
+            "cache_creation_tokens": 0,
+            "request_id": "req_a",
+            "cost_usd": 0.0043705,
+        },
+        {
+            "event": "api_request",
+            "model": "claude-fable-5-1",
+            "input_tokens": 2,
+            "output_tokens": 4,
+            "cache_read_tokens": 16602,
+            "cache_creation_tokens": 0,
+            "request_id": "req_a",
+        },  # duplicate export
+        {
+            "event": "api_request",
+            "model": "claude-haiku-4-5-20251001",
+            "input_tokens": 899,
+            "output_tokens": 8,
+            "cache_read_tokens": 0,
+            "cache_creation_tokens": 0,
+            "request_id": "req_b",
+            "cost_usd": 0.000939,
+        },
+        {
+            "event": "api_error",
+            "model": "claude-fable-5-1",
+            "status_code": 529,
+            "request_id": "req_c",
+        },
+    ]
+    (rollout / "trajectory" / "otel_usage.jsonl").write_text(
+        "\n".join(json.dumps(r) for r in rows) + "\n"
+    )
+
+    report = recompute_rollout_cost(rollout)
+    assert report.source == "otel_usage"
+    assert report.n_records == 2
+    by_model = {m.model: m for m in report.per_model}
+    assert by_model["claude-fable-5-1"].usage == UsageCounts(2, 4, 16602, 0)
+    fable = (2 * 10 + 4 * 50 + 16602 * 0.25) / MTOK
+    haiku = (899 * 1 + 8 * 5) / MTOK
+    # Claude Code's own cost_usd attributes agree with the list table to the micro-dollar
+    assert by_model["claude-fable-5-1"].cost_usd == pytest.approx(fable, abs=1e-6)
+    assert by_model["claude-haiku-4-5-20251001"].cost_usd == pytest.approx(
+        haiku, abs=1e-6
+    )
+    assert report.total_cost_usd == pytest.approx(fable + haiku)
+
+
+# ------------------------------------------------------------------ result.json aggregate fallback
+
+
+def test_recompute_from_result_aggregate_provider_response(tmp_path):
+    # Real FrontierPhysics slot (diffuse-ib-rigid-body-fsi / claude-fable-5-1 / max / trial-3)
+    result = {
+        "model": "claude-fable-5-1",
+        "agent_result": {
+            "n_input_tokens": 63728808,
+            "n_output_tokens": 424304,
+            "n_cache_read_tokens": 41121406,
+            "n_cache_creation_tokens": 11190144,
+            "cost_usd": 173.6434915,
+            "usage_source": "provider_response",
+            "price_source": "litellm",
+        },
+        "final_metrics": {"total_cost_usd": 173.6434915},
+    }
+    rollout = _write_rollout(tmp_path, model="claude-fable-5-1", result=result)
+    observed = recompute_rollout_cost(rollout, pricing=LITELLM_OBSERVED_FP_2026_09)
+    assert observed.source == "result_aggregate"
+    assert observed.total_cost_usd == pytest.approx(
+        173.6434915, rel=1e-9
+    )  # reproduces LiteLLM's figure
+    listed = recompute_rollout_cost(rollout)  # official list prices
+    uncached = 63728808 - 41121406 - 11190144
+    expected = (uncached * 10 + 424304 * 50 + 41121406 * 0.25 + 11190144 * 12.5) / MTOK
+    assert listed.total_cost_usd == pytest.approx(expected)
+    assert (
+        listed.total_cost_usd > observed.total_cost_usd
+    )  # cache writes under-priced by LiteLLM
+
+
+def test_recompute_from_result_aggregate_native_acp_is_uncached(tmp_path):
+    result = {
+        "model": "claude-opus-5",
+        "agent_result": {
+            "n_input_tokens": 100,  # claude-agent-acp: raw (uncached) inputTokens
+            "n_output_tokens": 10,
+            "n_cache_read_tokens": 1000,
+            "n_cache_creation_tokens": 200,
+            "cost_usd": None,
+            "usage_source": "agent_native_acp",
+            "price_source": None,
+        },
+        "final_metrics": {"total_cost_usd": None},
+    }
+    rollout = _write_rollout(tmp_path, model="claude-opus-5", result=result)
+    report = recompute_rollout_cost(rollout)
+    assert report.per_model[0].usage == UsageCounts(100, 10, 1000, 200)
+    assert report.recorded_cost_usd is None
+    assert report.total_cost_usd == pytest.approx(
+        (100 * 5 + 10 * 25 + 1000 * 0.5 + 200 * 6.25) / MTOK
+    )
+
+
+def test_source_override_and_missing_file(tmp_path):
+    rollout = _write_rollout(
+        tmp_path,
+        model="claude-opus-5",
+        result={"agent_result": {"n_input_tokens": 10, "n_output_tokens": 1}},
+    )
+    report = recompute_rollout_cost(rollout, source="otel_usage")
+    assert (
+        report.source == "otel_usage"
+        and report.n_records == 0
+        and report.total_cost_usd is None
+    )
+
+
+# ------------------------------------------------------------------ writers
+
+
+def test_write_report_and_update_result(tmp_path):
+    ex = _anthropic_exchange(
+        "claude-opus-5", {"input_tokens": MTOK, "output_tokens": 0}
+    )
+    rollout = _write_rollout(tmp_path, model="claude-opus-5", exchanges=[ex])
+    report = recompute_rollout_cost(rollout)
+    out = write_cost_report(report)
+    data = json.loads(out.read_text())
+    assert data["pricing_version"] == PRICING_VERSION
+    assert data["total_cost_usd"] == pytest.approx(5.0)
+    assert data["usage_totals"]["input_tokens"] == MTOK
+
+    update_result_json(report)
+    result = json.loads((rollout / "result.json").read_text())
+    assert result["final_metrics"]["total_cost_usd"] == pytest.approx(5.0)
+    assert result["agent_result"]["price_source"] == PRICING_VERSION
+    assert result["agent_result"]["cost_source"] == "llm_trajectory"
+    assert result["agent_result"]["cost_history"][0] == {
+        "cost_usd": 1.0,
+        "price_source": "litellm",
+        "replaced_at": report.computed_at,
+    }
+
+
+# ------------------------------------------------------------------ CLI
+
+
+def test_cli_cost_command(tmp_path):
+    from typer.testing import CliRunner
+
+    from benchflow.cli.main import app
+
+    ex = _anthropic_exchange(
+        "claude-opus-5", {"input_tokens": MTOK, "output_tokens": MTOK}
+    )
+    rollout = _write_rollout(tmp_path, model="claude-opus-5", exchanges=[ex])
+    runner = CliRunner()
+    res = runner.invoke(app, ["cost", str(rollout)])
+    assert res.exit_code == 0, res.output
+    assert (
+        "30.0000 USD" in res.output
+        and "llm_trajectory" in res.output
+        and "recorded 1.0000" in res.output
+    )
+
+    res = runner.invoke(app, ["cost", str(tmp_path), "--json", "--write"])
+    assert res.exit_code == 0, res.output
+    payload = json.loads(res.output)
+    assert payload[0]["total_cost_usd"] == pytest.approx(30.0)
+    assert (rollout / "cost_recompute.json").is_file()
+
+    res = runner.invoke(app, ["cost", "--list-tables"])
+    assert res.exit_code == 0, res.output
+    assert (
+        PRICING_VERSION in res.output
+        and LITELLM_OBSERVED_FP_2026_09.version in res.output
+    )
+
+    res = runner.invoke(app, ["cost", str(rollout), "--pricing", "bogus"])
+    assert res.exit_code == 2


### PR DESCRIPTION
# PR: Post-hoc cost from recorded usage + OAuth-mode usage capture (`feat/oauth-usage-cost`)

Branch: `feat/oauth-usage-cost`, commit `1aeef152` on top of main `a0b16985` (local clone at `~/fp-worker-home/repos/benchflow`). Not pushed; open the PR from this branch.

## Why

benchflow's `total_cost_usd` is whatever LiteLLM computed at run time, and in OAuth / subscription mode (Claude Code logged in with a claude.ai account) the proxy sees no traffic at all, so `cost_usd` is `None`. The FrontierPhysics run showed the first problem concretely: fitting the 538 recorded `result.json` files gives the effective prices LiteLLM used — cache writes at 0.25x the input price for all three models, versus the official 1.25x. At list prices the run cost $37,356, not the recorded $30,040 (+24 %).

Design note with the investigation: `OAUTH_USAGE_DESIGN.md`. Decision implemented here: record usage per turn for every run mode, compute cost post hoc from a version-stamped list-price table.

## What this PR adds

- `benchflow/pricing.py` — `LIST_PRICES` (USD/MTok: input, output, cache_read, cache_write_5m, cache_write_1h) for the current Claude models with `PRICING_VERSION = "anthropic-list-2026-09-07"`, `canonical_model()` (strips `anthropic/`, Bedrock region/version, `[1m]`, dated snapshots), `UsageCounts` (Anthropic additive convention with a converter from benchflow's cache-inclusive `n_input_tokens`), `compute_cost()`. A second table `LITELLM_OBSERVED_FP_2026_09` holds the prices LiteLLM effectively applied in the FP run, for reproduction only.
- `benchflow/cost.py` — `recompute_rollout_cost(rollout_dir, pricing=..., source=auto)` reads per-turn usage from `trajectory/llm_trajectory.jsonl` (LiteLLM), `trajectory/otel_usage.jsonl` (new OAuth capture) or falls back to the `result.json` aggregate; per-model totals and cost; `write_cost_report()` -> `cost_recompute.json`; `update_result_json()` rewrites `final_metrics.total_cost_usd` / `agent_result.cost_usd` / `price_source` and keeps the old values in `agent_result.cost_history`.
- `benchflow/otel_capture.py` — `OtelUsageReceiver`: a threaded OTLP/HTTP JSON endpoint that turns Claude Code's `claude_code.api_request` / `api_error` log records into `trajectory/otel_usage.jsonl` (model, uncached input, output, cache read, cache creation, duration_ms, request_id, query_source, effort, Claude Code's own cost_usd); `agent_env(endpoint)` gives the env vars to inject (`CLAUDE_CODE_ENABLE_TELEMETRY=1`, `OTEL_LOGS_EXPORTER=otlp`, `OTEL_EXPORTER_OTLP_PROTOCOL=http/json`, ...). Verified against a real Claude Code 2.1.263 export; the captured payload is the test fixture.
- `bench cost <rollout_dir>... [--pricing list|<table>] [--source auto|llm_trajectory|otel_usage|result_aggregate] [--json] [--write] [--update-result] [--list-tables]` (`benchflow/cli/cost.py`, registered in `cli/main.py`).
- Tests: `tests/test_pricing_cost.py` (25) and `tests/test_otel_capture.py` (4), fixtures under `tests/fixtures/otel/`.

Not in this PR (follow-ups listed in the design note): starting the receiver from `Rollout` and injecting the env into the sandbox; a new trusted `usage_source` value for the OTEL path; the per-turn (not cumulative) handling of claude-agent-acp's `PromptResponse.usage`.

## Verification

- `pytest tests/test_pricing_cost.py tests/test_otel_capture.py` — 29 passed. `pytest tests/test_usage_tracking.py tests/test_native_acp_usage.py tests/test_token_usage_normalization.py tests/test_usage_litellm.py` — 39 passed (no regressions). `ruff check`, `ruff format --check` and `ty check` clean on the new files; CHANGELOG `[Unreleased]` entry added.
- Reproduction on the FrontierPhysics data: `bench cost <dir> --pricing litellm-observed-fp-2026-09` reproduces `final_metrics.total_cost_usd` on **538 / 538** result dirs (worst relative error 3.5e-16); with the default list table the same dirs total $37,355.85 vs recorded $30,039.91. Example (`max/arpes-sample-alignment/claude-fable-5-1/trial-1`): recorded 58.9157, observed-table 58.9157, list 87.1442.
- Per-call path: exercised on synthetic `llm_trajectory.jsonl` (Anthropic and OpenAI usage conventions, failed calls, unknown model) and on a 33-call sample converted from a local Claude Code transcript (`bench cost` reports 33 records, $9.71 at list prices). The FP per-call trajectories live in the HF bucket and could not be downloaded from the build host (no token), so per-call reproduction of the FP totals is not claimed.
- OTEL path: real Claude Code run against the receiver produced `api_request` events for both the main Fable 5.1 call and the auxiliary Haiku call; parsed tokens and Claude Code's `cost_usd` agree with the list table to the micro-dollar.

## Notes for reviewers

- Input-token convention: benchflow's normalized `n_input_tokens` is cache-inclusive for `provider_response` but uncached for `agent_native_acp` (claude-agent-acp forwards the SDK's raw `inputTokens`). `cost.py` compensates per source; unifying this in `rollout/_usage.py` is a follow-up.
- Prices are data; when Anthropic changes a price, add a new `PriceTable` with a new version string rather than editing `LIST_PRICES` in place, so recorded `price_source` stays meaningful.
- The 1 h cache-write TTL is priced at 2x when the source carries the split (`cache_creation.ephemeral_1h_input_tokens`); LiteLLM and OTEL records do not carry it, so they are priced at the 5 m rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Aggregation convention (owner decision, 2026-09-07)
When reporting cost per task / model / leaderboard, sum only over rollouts that completed and were scored (no `error_category`, no agent error). Timed-out and infrastructure-failed rollouts keep their per-rollout `bench cost` (for auditing) but are excluded from aggregate spend. For the FrontierPhysics 538 final slots this is $27,546 (successful) vs $30,040 (all) at LiteLLM-observed prices.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/1108" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->