### PR TITLE
feat: expose custom rollout planes through SDK.run

### DIFF
--- a/src/benchflow/rollout/__init__.py
+++ b/src/benchflow/rollout/__init__.py
@@ -629,7 +629,9 @@ class Rollout:
     """Decomposed trial lifecycle with independently-callable phases."""
 
     def __init__(self, config: RolloutConfig) -> None:
-        self._planes = config.planes or default_rollout_planes()
+        self._planes = (
+            config.planes if config.planes is not None else default_rollout_planes()
+        )
         # Activate Docker DinD compatibility shim on first rollout
         # construction (idempotent). Keeps `import benchflow.rollout`
         # side-effect free with respect to sandbox/provider behavior.

--- a/src/benchflow/sdk.py
+++ b/src/benchflow/sdk.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any
 
 from benchflow._types import Scene
-from benchflow.contracts import default_rollout_planes
+from benchflow.contracts import RolloutPlanes, default_rollout_planes
 from benchflow.diagnostics import VerifierTimeoutDiagnostic
 from benchflow.environment.manifest import EnvironmentManifest
 from benchflow.models import RolloutResult, TrajectorySource
@@ -175,6 +175,7 @@ class SDK:
         self_gen_no_internet: bool = False,
         source_provenance: dict[str, Any] | None = None,
         usage_tracking: Any = None,
+        planes: RolloutPlanes | None = None,
     ) -> RolloutResult:
         """Run a task — delegates to :func:`benchflow.run`.
 
@@ -182,6 +183,9 @@ class SDK:
         backward compatibility with pre-v0.6 callers. Passing it emits a
         :class:`DeprecationWarning` and maps to ``rollout_name``. Passing both
         ``trial_name`` and ``rollout_name`` raises :class:`TypeError`.
+
+        ``planes`` supplies rollout composition for this run. ``None`` uses
+        the default planes.
         """
         from benchflow.rollout import RolloutConfig
         from benchflow.runtime import run
@@ -225,5 +229,6 @@ class SDK:
             self_gen_no_internet=self_gen_no_internet,
             source_provenance=source_provenance,
             usage_tracking=usage_tracking,
+            planes=planes,
         )
         return await run(config)  # type: ignore[return-value]  # ty: ignore[invalid-return-type]

--- a/tests/test_sdk_internals.py
+++ b/tests/test_sdk_internals.py
@@ -705,19 +705,15 @@ class TestRunWiring:
         assert seen["config"].sandbox_setup_timeout == 77
         assert seen["config"].task_path == tmp_path
 
-    @pytest.mark.parametrize(
-        "custom_planes", [None, MagicMock()], ids=["default", "custom"]
-    )
     @pytest.mark.asyncio
-    async def test_run_forwards_planes_to_rollout_config(
-        self, monkeypatch, tmp_path, custom_planes
-    ):
-        """Guards the SDK custom-planes PR, including default composition."""
+    async def test_run_forwards_false_valued_custom_planes(self, monkeypatch, tmp_path):
         from benchflow.models import RunResult
         from benchflow.rollout import Rollout
         from benchflow.sdk import SDK
 
         seen = {}
+        custom_planes = MagicMock()
+        custom_planes.__bool__.return_value = False
 
         async def fake_create(config):
             seen["config"] = config
@@ -733,8 +729,7 @@ class TestRunWiring:
         await SDK().run(task_path=tmp_path, planes=custom_planes)
 
         assert seen["config"].planes is custom_planes
-        if custom_planes is not None:
-            assert seen["trial"]._planes is custom_planes
+        assert seen["trial"]._planes is custom_planes
 
     @pytest.mark.asyncio
     async def test_run_forwards_source_provenance_to_rollout_config(

--- a/tests/test_sdk_internals.py
+++ b/tests/test_sdk_internals.py
@@ -7,7 +7,7 @@ independently testable private methods.
 import json
 from datetime import datetime
 from pathlib import Path
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -704,6 +704,37 @@ class TestRunWiring:
         assert result.rewards == {"reward": 1.0}
         assert seen["config"].sandbox_setup_timeout == 77
         assert seen["config"].task_path == tmp_path
+
+    @pytest.mark.parametrize(
+        "custom_planes", [None, MagicMock()], ids=["default", "custom"]
+    )
+    @pytest.mark.asyncio
+    async def test_run_forwards_planes_to_rollout_config(
+        self, monkeypatch, tmp_path, custom_planes
+    ):
+        """Guards the SDK custom-planes PR, including default composition."""
+        from benchflow.models import RunResult
+        from benchflow.rollout import Rollout
+        from benchflow.sdk import SDK
+
+        seen = {}
+
+        async def fake_create(config):
+            seen["config"] = config
+            trial = Rollout(config)
+            trial.run = AsyncMock(
+                return_value=RunResult(task_name="task-1", rewards={"reward": 1.0})
+            )
+            seen["trial"] = trial
+            return trial
+
+        monkeypatch.setattr("benchflow.rollout.Rollout.create", fake_create)
+
+        await SDK().run(task_path=tmp_path, planes=custom_planes)
+
+        assert seen["config"].planes is custom_planes
+        if custom_planes is not None:
+            assert seen["trial"]._planes is custom_planes
 
     @pytest.mark.asyncio
     async def test_run_forwards_source_provenance_to_rollout_config(

--- a/tests/test_sdk_internals.py
+++ b/tests/test_sdk_internals.py
@@ -707,6 +707,7 @@ class TestRunWiring:
 
     @pytest.mark.asyncio
     async def test_run_forwards_false_valued_custom_planes(self, monkeypatch, tmp_path):
+        """Guards PR #1110: valid false-valued plane objects retain identity."""
         from benchflow.models import RunResult
         from benchflow.rollout import Rollout
         from benchflow.sdk import SDK


### PR DESCRIPTION
## Problem

`RolloutConfig` already supports custom `RolloutPlanes`, but `SDK.run()` did not expose that composition point. High-level SDK callers therefore could not provide per-run plane behavior without bypassing the SDK or modifying global defaults.

## Change

Add an optional `planes` argument to `SDK.run()` and forward it unchanged to `RolloutConfig`:

```python
await SDK().run(..., planes=my_rollout_planes)
```

Omitting the argument preserves current default behavior. This reuses the existing plane contract; no factory, policy framework, or new lifecycle abstraction is introduced.

## Relationship to #1107

Refs #1107. This supplies a supported integration point for consumers to apply agent-specific connector and credential policies per rollout without global monkey patches. It does **not** define a connector policy, disable hosted Apps/MCP, validate an effective tool inventory, or fully address #1107.

## Validation

- 51 targeted tests passed
- Ruff and formatting passed
- `ty check src/` passed

Full-suite note: three host-sensitive failures were reproduced as environmental. Two credential tests observed the existing host Claude login, and one terminal assertion wrapped at the current Rich console width; those tests pass with a sterile home and wider terminal.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/1110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->