### PR TITLE
fix: preserve safe ACP tool provenance in trajectories

### DIFF
--- a/src/benchflow/acp/session.py
+++ b/src/benchflow/acp/session.py
@@ -456,9 +456,11 @@ class ACPSession:
             if record is not None and not record.initial_received:
                 record.initial_received = True
                 record.title = update.get("title", "")
-                record.kind = _canonical_tool_kind(
+                initial_kind = _canonical_tool_kind(
                     update.get("kind", "other"), record.title
                 )
+                if record.kind != "skill":
+                    record.kind = initial_kind
                 record.update_metadata(_tool_provenance_metadata(update))
                 self._seen_tool_titles.add(
                     _tool_display_title(record.title, record.kind)

--- a/src/benchflow/acp/session.py
+++ b/src/benchflow/acp/session.py
@@ -1,5 +1,6 @@
 """ACP session lifecycle management."""
 
+import copy
 import logging
 import os
 import time
@@ -156,10 +157,20 @@ class ToolCallRecord:
     content blocks, and wall-clock timing.
     """
 
-    def __init__(self, tool_call_id: str, title: str, kind: str):
+    def __init__(
+        self,
+        tool_call_id: str,
+        title: str,
+        kind: str,
+        metadata: dict[str, Any] | None = None,
+        *,
+        initial_received: bool = True,
+    ):
         self.tool_call_id = tool_call_id
         self.title = title
         self.kind = kind
+        self.metadata = copy.deepcopy(metadata or {})
+        self.initial_received = initial_received
         self.status = ToolCallStatus.PENDING
         self.content: list[dict] = []
         self.started_at = datetime.now()
@@ -177,6 +188,36 @@ class ToolCallRecord:
             ToolCallStatus.CANCELLED,
         ):
             self.finished_at = datetime.now()
+
+    def update_metadata(self, metadata: dict[str, Any]) -> None:
+        """Merge filtered ACP metadata without retaining producer-owned objects."""
+        _merge_metadata(self.metadata, metadata)
+
+
+def _merge_metadata(target: dict[str, Any], update: dict[str, Any]) -> None:
+    for key, value in update.items():
+        if isinstance(value, dict) and isinstance(target.get(key), dict):
+            _merge_metadata(target[key], value)
+        else:
+            target[key] = copy.deepcopy(value)
+
+
+def _tool_provenance_metadata(update: dict[str, Any]) -> dict[str, Any]:
+    """Keep documented, non-payload tool origin markers from ACP ``_meta``."""
+    metadata = update.get("_meta")
+    if not isinstance(metadata, dict):
+        return {}
+
+    safe: dict[str, Any] = {}
+    if metadata.get("is_mcp_tool_call") is True:
+        safe["is_mcp_tool_call"] = True
+
+    claude_code = metadata.get("claudeCode")
+    if isinstance(claude_code, dict):
+        tool_name = claude_code.get("toolName")
+        if isinstance(tool_name, str) and tool_name:
+            safe["claudeCode"] = {"toolName": tool_name}
+    return safe
 
 
 class ACPSession:
@@ -410,14 +451,42 @@ class ACPSession:
 
         if update_type == "tool_call":
             self._flush_agent_text()
-            record = ToolCallRecord(
-                tool_call_id=update.get("toolCallId", ""),
-                title=update.get("title", ""),
-                kind=_canonical_tool_kind(
-                    update.get("kind", "other"), update.get("title", "")
-                ),
-            )
-            self._record_tool_call(record)
+            tc_id = update.get("toolCallId", "")
+            record = self._tool_call_map.get(tc_id)
+            if record is not None and not record.initial_received:
+                record.initial_received = True
+                record.title = update.get("title", "")
+                record.kind = _canonical_tool_kind(
+                    update.get("kind", "other"), record.title
+                )
+                record.update_metadata(_tool_provenance_metadata(update))
+                self._seen_tool_titles.add(
+                    _tool_display_title(record.title, record.kind)
+                )
+                content = update.get("content")
+                if content:
+                    record.content.extend(content)
+                if "status" in update and record.status not in {
+                    ToolCallStatus.COMPLETED,
+                    ToolCallStatus.FAILED,
+                    ToolCallStatus.CANCELLED,
+                }:
+                    try:
+                        record.update_status(ToolCallStatus(update["status"]))
+                    except ValueError:
+                        logger.warning(
+                            f"Unknown tool call status: {update.get('status')}"
+                        )
+            else:
+                record = ToolCallRecord(
+                    tool_call_id=tc_id,
+                    title=update.get("title", ""),
+                    kind=_canonical_tool_kind(
+                        update.get("kind", "other"), update.get("title", "")
+                    ),
+                    metadata=_tool_provenance_metadata(update),
+                )
+                self._record_tool_call(record)
 
         elif update_type == "tool_call_update":
             self.tool_call_update_count += 1
@@ -431,8 +500,12 @@ class ACPSession:
                     kind=_canonical_tool_kind(
                         update.get("kind", "tool"), update.get("title", "")
                     ),
+                    metadata=_tool_provenance_metadata(update),
+                    initial_received=False,
                 )
                 self._record_tool_call(record)
+            else:
+                record.update_metadata(_tool_provenance_metadata(update))
             try:
                 status = ToolCallStatus(update.get("status", "in_progress"))
             except ValueError:

--- a/src/benchflow/acp/session.py
+++ b/src/benchflow/acp/session.py
@@ -468,17 +468,9 @@ class ACPSession:
                 content = update.get("content")
                 if content:
                     record.content.extend(content)
-                if "status" in update and record.status not in {
-                    ToolCallStatus.COMPLETED,
-                    ToolCallStatus.FAILED,
-                    ToolCallStatus.CANCELLED,
-                }:
-                    try:
-                        record.update_status(ToolCallStatus(update["status"]))
-                    except ValueError:
-                        logger.warning(
-                            f"Unknown tool call status: {update.get('status')}"
-                        )
+                # This initial notification arrived after at least one update.
+                # Preserve the newer update's status instead of moving the
+                # lifecycle backwards (for example, in_progress -> pending).
             else:
                 record = ToolCallRecord(
                     tool_call_id=tc_id,

--- a/src/benchflow/trajectories/_capture.py
+++ b/src/benchflow/trajectories/_capture.py
@@ -70,16 +70,17 @@ def _events_to_trajectory(events: list[dict]) -> list[dict]:
     for event in events:
         if event["type"] == "tool_call":
             tc = event["record"]
-            out.append(
-                {
-                    "type": "tool_call",
-                    "tool_call_id": tc.tool_call_id,
-                    "kind": tc.kind,
-                    "title": tc.title,
-                    "status": tc.status.value,
-                    "content": tc.content,
-                }
-            )
+            captured = {
+                "type": "tool_call",
+                "tool_call_id": tc.tool_call_id,
+                "kind": tc.kind,
+                "title": tc.title,
+                "status": tc.status.value,
+                "content": tc.content,
+            }
+            if tc.metadata:
+                captured["_meta"] = tc.metadata
+            out.append(captured)
         elif event["type"] in ("user_message", "agent_message", "agent_thought"):
             out.append({"type": event["type"], "text": event["text"]})
         elif event["type"] == "agent_timeout":
@@ -205,16 +206,17 @@ def _capture_session_trajectory(session: ACPSession | None) -> list[dict]:
     # handle_update). Preserves the old flat behaviour.
     trajectory = []
     for tc in session.tool_calls:
-        trajectory.append(
-            {
-                "type": "tool_call",
-                "tool_call_id": tc.tool_call_id,
-                "kind": tc.kind,
-                "title": tc.title,
-                "status": tc.status.value,
-                "content": tc.content,
-            }
-        )
+        captured = {
+            "type": "tool_call",
+            "tool_call_id": tc.tool_call_id,
+            "kind": tc.kind,
+            "title": tc.title,
+            "status": tc.status.value,
+            "content": tc.content,
+        }
+        if tc.metadata:
+            captured["_meta"] = tc.metadata
+        trajectory.append(captured)
     if session.full_message:
         trajectory.append({"type": "agent_message", "text": session.full_message})
     if session.full_thought:

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -226,7 +226,7 @@ class TestACPSession:
         assert session.tool_calls[0].status == ToolCallStatus.COMPLETED
 
     def test_tool_provenance_merges_only_documented_safe_metadata(self):
-        """Guards acp-tool-provenance against losing origin or retaining payloads."""
+        """Guards PR #1111 against losing origin or retaining metadata payloads."""
         session = ACPSession("test-session")
         initial_meta = {
             "claudeCode": {
@@ -263,7 +263,7 @@ class TestACPSession:
         }
 
     def test_delayed_tool_call_reconciles_update_fallback_in_place(self):
-        """Guards acp-tool-provenance against duplicate out-of-order records."""
+        """Guards PR #1111 against duplicate out-of-order tool records."""
         session = ACPSession("test-session")
         session.record_user_prompt("search")
         session.handle_update(
@@ -324,6 +324,7 @@ class TestACPSession:
         ]
 
     def test_delayed_tool_call_preserves_skill_inferred_from_update(self):
+        """Guards PR #1111: delayed initial calls preserve inferred skill kind."""
         session = ACPSession("test-session")
         session.handle_update(
             {

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -225,6 +225,129 @@ class TestACPSession:
         )
         assert session.tool_calls[0].status == ToolCallStatus.COMPLETED
 
+    def test_tool_provenance_merges_only_documented_safe_metadata(self):
+        """Guards acp-tool-provenance against losing origin or retaining payloads."""
+        session = ACPSession("test-session")
+        initial_meta = {
+            "claudeCode": {
+                "toolName": "mcp__google_drive__search",
+                "toolResponse": {"access_token": "secret"},
+            },
+            "unknown": {"authorization": "secret"},
+        }
+        session.handle_update(
+            {
+                "sessionUpdate": "tool_call",
+                "toolCallId": "tc_1",
+                "title": "Search Drive",
+                "kind": "other",
+                "_meta": initial_meta,
+            }
+        )
+        initial_meta["claudeCode"]["toolName"] = "mutated"
+        session.handle_update(
+            {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "tc_1",
+                "status": "completed",
+                "_meta": {
+                    "is_mcp_tool_call": True,
+                    "mcp_output_delta": {"data": "sensitive output"},
+                },
+            }
+        )
+
+        assert session.tool_calls[0].metadata == {
+            "claudeCode": {"toolName": "mcp__google_drive__search"},
+            "is_mcp_tool_call": True,
+        }
+
+    def test_unknown_tool_call_update_keeps_safe_provenance(self):
+        """Guards acp-tool-provenance for agents that omit initial tool_call."""
+        session = ACPSession("test-session")
+        session.handle_update(
+            {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "tc_1",
+                "status": "completed",
+                "_meta": {"claudeCode": {"toolName": "mcp__slack__search"}},
+            }
+        )
+
+        assert session.tool_calls[0].metadata == {
+            "claudeCode": {"toolName": "mcp__slack__search"}
+        }
+
+    def test_delayed_tool_call_reconciles_update_fallback_in_place(self):
+        """Guards acp-tool-provenance against duplicate out-of-order records."""
+        session = ACPSession("test-session")
+        session.record_user_prompt("search")
+        session.handle_update(
+            {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "tc_1",
+                "title": "pending tool",
+                "kind": "other",
+                "status": "in_progress",
+                "content": [
+                    {"type": "content", "content": {"type": "text", "text": "starting"}}
+                ],
+                "_meta": {"is_mcp_tool_call": True},
+            }
+        )
+        session.handle_update(
+            {
+                "sessionUpdate": "tool_call",
+                "toolCallId": "tc_1",
+                "title": "Search Drive",
+                "kind": "execute",
+                "status": "in_progress",
+                "content": [
+                    {"type": "content", "content": {"type": "text", "text": "ready"}}
+                ],
+                "_meta": {"claudeCode": {"toolName": "mcp__google_drive__search"}},
+            }
+        )
+        session.handle_update(
+            {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "tc_1",
+                "status": "completed",
+                "content": [
+                    {"type": "content", "content": {"type": "text", "text": "done"}}
+                ],
+            }
+        )
+
+        assert len(session.tool_calls) == 1
+        record = session.tool_calls[0]
+        assert record.tool_call_id == "tc_1"
+        assert record.title == "Search Drive"
+        assert record.kind == "execute"
+        assert record.status == ToolCallStatus.COMPLETED
+        assert [block["content"]["text"] for block in record.content] == [
+            "starting",
+            "ready",
+            "done",
+        ]
+        assert record.metadata == {
+            "is_mcp_tool_call": True,
+            "claudeCode": {"toolName": "mcp__google_drive__search"},
+        }
+        assert [event["type"] for event in session.events] == [
+            "user_message",
+            "tool_call",
+        ]
+        from benchflow.trajectories._capture import _capture_session_trajectory
+
+        (captured,) = [
+            event
+            for event in _capture_session_trajectory(session)
+            if event["type"] == "tool_call"
+        ]
+        assert captured["status"] == "completed"
+        assert captured["_meta"] == record.metadata
+
     def test_handle_openhands_invoke_skill_update_marks_kind_skill(self):
         """Guards issue #507: OpenHands invoke_skill ACP calls are canonicalized."""
         session = ACPSession("test-session")

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -323,6 +323,28 @@ class TestACPSession:
             "tool_call",
         ]
 
+    def test_delayed_tool_call_does_not_regress_update_status(self):
+        """Guards PR #1111 against regressing a newer out-of-order status."""
+        session = ACPSession("test-session")
+        session.handle_update(
+            {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "tc_1",
+                "status": "in_progress",
+            }
+        )
+        session.handle_update(
+            {
+                "sessionUpdate": "tool_call",
+                "toolCallId": "tc_1",
+                "title": "Delayed initial call",
+                "kind": "execute",
+                "status": "pending",
+            }
+        )
+
+        assert session.tool_calls[0].status == ToolCallStatus.IN_PROGRESS
+
     def test_delayed_tool_call_preserves_skill_inferred_from_update(self):
         """Guards PR #1111: delayed initial calls preserve inferred skill kind."""
         session = ACPSession("test-session")

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -262,22 +262,6 @@ class TestACPSession:
             "is_mcp_tool_call": True,
         }
 
-    def test_unknown_tool_call_update_keeps_safe_provenance(self):
-        """Guards acp-tool-provenance for agents that omit initial tool_call."""
-        session = ACPSession("test-session")
-        session.handle_update(
-            {
-                "sessionUpdate": "tool_call_update",
-                "toolCallId": "tc_1",
-                "status": "completed",
-                "_meta": {"claudeCode": {"toolName": "mcp__slack__search"}},
-            }
-        )
-
-        assert session.tool_calls[0].metadata == {
-            "claudeCode": {"toolName": "mcp__slack__search"}
-        }
-
     def test_delayed_tool_call_reconciles_update_fallback_in_place(self):
         """Guards acp-tool-provenance against duplicate out-of-order records."""
         session = ACPSession("test-session")
@@ -338,15 +322,35 @@ class TestACPSession:
             "user_message",
             "tool_call",
         ]
-        from benchflow.trajectories._capture import _capture_session_trajectory
 
-        (captured,) = [
-            event
-            for event in _capture_session_trajectory(session)
-            if event["type"] == "tool_call"
-        ]
-        assert captured["status"] == "completed"
-        assert captured["_meta"] == record.metadata
+    def test_delayed_tool_call_preserves_skill_inferred_from_update(self):
+        session = ACPSession("test-session")
+        session.handle_update(
+            {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "tc_1",
+                "status": "completed",
+                "content": [
+                    {
+                        "type": "content",
+                        "content": {
+                            "type": "text",
+                            "text": "Tool: invoke_skill\nResult:\n[skill: pdf]",
+                        },
+                    }
+                ],
+            }
+        )
+        session.handle_update(
+            {
+                "sessionUpdate": "tool_call",
+                "toolCallId": "tc_1",
+                "title": "Load PDF skill",
+                "kind": "other",
+            }
+        )
+
+        assert session.tool_calls[0].kind == "skill"
 
     def test_handle_openhands_invoke_skill_update_marks_kind_skill(self):
         """Guards issue #507: OpenHands invoke_skill ACP calls are canonicalized."""

--- a/tests/test_capture_trajectory.py
+++ b/tests/test_capture_trajectory.py
@@ -16,6 +16,33 @@ from benchflow.trajectories._capture import (
 from benchflow.trajectories.types import LLMExchange, LLMRequest, LLMResponse
 
 
+def test_acp_tool_provenance_is_additive_and_absent_by_default():
+    """Guards acp-tool-provenance in final trajectory capture."""
+    session = ACPSession("test-session")
+    session.handle_update(
+        {
+            "sessionUpdate": "tool_call",
+            "toolCallId": "mcp-1",
+            "title": "mcp.google_drive.search",
+            "kind": "execute",
+            "_meta": {"is_mcp_tool_call": True, "unknown": "drop me"},
+        }
+    )
+    session.handle_update(
+        {
+            "sessionUpdate": "tool_call",
+            "toolCallId": "shell-1",
+            "title": "pwd",
+            "kind": "execute",
+        }
+    )
+
+    trajectory = _capture_session_trajectory(session)
+
+    assert trajectory[0]["_meta"] == {"is_mcp_tool_call": True}
+    assert "_meta" not in trajectory[1]
+
+
 def test_pr_942_backfills_empty_gemini_acp_observation_by_exact_id():
     """Guards PR #942: rubric evidence retains Gemini-native tool results."""
 

--- a/tests/test_capture_trajectory.py
+++ b/tests/test_capture_trajectory.py
@@ -17,7 +17,7 @@ from benchflow.trajectories.types import LLMExchange, LLMRequest, LLMResponse
 
 
 def test_acp_tool_provenance_is_additive_and_absent_by_default():
-    """Guards acp-tool-provenance in final trajectory capture."""
+    """Guards PR #1111 provenance shape in final trajectory capture."""
     session = ACPSession("test-session")
     session.handle_update(
         {


### PR DESCRIPTION
## Problem

ACP tool-call updates can include origin metadata, but trajectory capture discarded it. Downstream consumers therefore lose evidence needed to distinguish MCP or agent-specific tool origins.

## Change

- Preserve a narrow allowlist of producer metadata:
  - `_meta.is_mcp_tool_call`
  - `_meta.claudeCode.toolName`
- Merge provenance across tool-call updates and deep-copy retained values.
- Exclude arbitrary or potentially sensitive `_meta` fields.
- Emit additive `_meta` only when supported provenance exists.
- Reconcile update-before-call ordering in place so delayed initial calls do not create duplicate records or split provenance from terminal status.

Existing tool events without provenance retain their current shape. This PR records evidence only; it introduces no allow/deny or quarantine policy.

## Relationship to #1107

Refs #1107. The issue requires trajectories to retain enough origin evidence to audit undeclared hosted connector use. This PR improves that evidence path, but it does **not** block connector calls before execution, enforce task-declared MCP allowlists, quarantine scores, or fully address #1107.

## Validation

- 163 focused ACP and trajectory tests passed
- Ruff passed
- `ty check src/` passed
- `git diff --check` passed

Full-suite note: three host-sensitive failures were reproduced as environmental. Two credential tests observed the existing host Claude login, and one terminal assertion wrapped at the current Rich console width; those tests pass with a sterile home and wider terminal.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/1111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->