### PR TITLE
fix(sandbox): reject pytest plugins backed by agent-writable code

### DIFF
--- a/src/benchflow/sandbox/lockdown.py
+++ b/src/benchflow/sandbox/lockdown.py
@@ -518,14 +518,23 @@ def _verifier_confcutdir(task: "Task") -> str:
 #              such a plugin by its dist-info alone admits agent-owned code.
 #
 # Resolving the module covers both: a forged registration resolves into the
-# workspace, and an editable project resolves to its workspace source. The
-# resolution deliberately uses the full ``sys.path`` rather than a pre-filtered
-# one, because the question is which file pytest will actually import, not
-# which one it ideally would: a workspace module shadowing a system plugin of
-# the same name is what gets loaded, so it is what has to be judged. Only the
-# top-level name is resolved, and only through ``PathFinder``, which locates
-# modules without importing them — importing here would run the very code this
-# is deciding whether to trust.
+# workspace, and an editable project resolves to its workspace source. Three
+# things about how that resolution is done are load-bearing:
+#
+#   * It goes through ``PathFinder``, which locates modules without importing
+#     them — importing here would run the very code this is deciding whether
+#     to trust.
+#   * The first component is resolved against the full ``sys.path``, not a
+#     pre-filtered one, because the question is which file pytest will
+#     actually import, not which one it ideally would: a workspace module
+#     shadowing a system plugin of the same name is what gets loaded.
+#   * A dotted target is walked one component at a time, each step searching
+#     only the locations its parent declares. Checking the top level alone
+#     would clear ``trusted_pkg.evil`` on the strength of ``trusted_pkg``,
+#     and a pkgutil-style namespace package widens its ``__path__`` at import
+#     time to every same-named directory on ``sys.path`` — the workspace
+#     included — which ``find_spec`` never sees. A component living only in
+#     the workspace then resolves nowhere and the entry point is refused.
 #
 # ``argv[1]`` is the JSON list of agent-writable path prefixes.
 _DISCOVER_PYTEST_PLUGINS_SCRIPT = r"""
@@ -563,23 +572,29 @@ try:
         eps = list(entry_points().get('pytest11', []))
     names = []
     for ep in eps:
-        top = ep.value.split(':')[0].strip().split('.')[0]
-        if not top:
+        parts = [p for p in ep.value.split(':')[0].strip().split('.') if p]
+        if not parts:
             continue
-        try:
-            spec = PathFinder.find_spec(top)
-        except Exception:
-            continue
-        if spec is None:
-            continue
-        # A namespace package has no origin, only search locations; a builtin
-        # has a non-path origin. Requiring at least one real path keeps both
-        # from passing by vacuous truth.
-        locations = [spec.origin] if (spec.origin or "").startswith("/") else []
-        locations += [str(p) for p in (spec.submodule_search_locations or [])]
-        if not locations or not all(trusted(p) for p in locations):
-            continue
-        names.append(ep.name)
+        search = None
+        for i, part in enumerate(parts):
+            try:
+                spec = PathFinder.find_spec('.'.join(parts[:i + 1]), path=search)
+            except Exception:
+                break
+            if spec is None:
+                break
+            # A namespace package has no origin, only search locations; a
+            # builtin has a non-path origin. Requiring at least one real path
+            # keeps both from passing by vacuous truth.
+            locations = [spec.origin] if (spec.origin or "").startswith("/") else []
+            locations += [str(p) for p in (spec.submodule_search_locations or [])]
+            if not locations or not all(trusted(p) for p in locations):
+                break
+            search = [str(p) for p in (spec.submodule_search_locations or [])]
+            if i < len(parts) - 1 and not search:
+                break
+        else:
+            names.append(ep.name)
     print(json.dumps(sorted(set(names))))
 except Exception as e:
     print(json.dumps({"error": str(e)}), file=sys.stderr)

--- a/src/benchflow/sandbox/lockdown.py
+++ b/src/benchflow/sandbox/lockdown.py
@@ -502,19 +502,85 @@ def _verifier_confcutdir(task: "Task") -> str:
 
 
 # Container-side script to enumerate pre-installed pytest11 entry points.
-# Runs after sandbox_user processes are killed, so the agent cannot install
-# new packages between enumeration and verification. The sandbox_user cannot
-# pip install (not root), so all discovered plugins are image-authored.
+#
+# Discovery decides what goes on the verifier's ``-p`` allowlist, so a plugin
+# reaching this list executes *inside* pytest with the power to rewrite a test
+# report. A pytest11 entry point is therefore only trusted when the code it
+# resolves to is root-owned and outside every agent-writable tree; both halves
+# are needed, and neither is implied by the other:
+#
+#   forged   — ``importlib.metadata`` reads ``*.dist-info`` straight off
+#              ``sys.path``, needing neither pip nor root, so the sandbox user
+#              can register a plugin by creating a directory in its workspace.
+#   editable — a root-installed editable project puts a root-owned dist-info in
+#              site-packages while its *source* stays in the workspace, and
+#              adds that workspace path to ``sys.path`` via a ``.pth``. Judging
+#              such a plugin by its dist-info alone admits agent-owned code.
+#
+# Resolving the module covers both: a forged registration resolves into the
+# workspace, and an editable project resolves to its workspace source. The
+# resolution deliberately uses the full ``sys.path`` rather than a pre-filtered
+# one, because the question is which file pytest will actually import, not
+# which one it ideally would: a workspace module shadowing a system plugin of
+# the same name is what gets loaded, so it is what has to be judged. Only the
+# top-level name is resolved, and only through ``PathFinder``, which locates
+# modules without importing them — importing here would run the very code this
+# is deciding whether to trust.
+#
+# ``argv[1]`` is the JSON list of agent-writable path prefixes.
 _DISCOVER_PYTEST_PLUGINS_SCRIPT = r"""
-import json, sys
+import json, os, stat, sys
+from importlib.machinery import PathFinder
+
+blocked = tuple(json.loads(sys.argv[1]))
+
+
+def under(path, prefix):
+    prefix = prefix.rstrip("/")
+    return path == prefix or path.startswith(prefix + "/")
+
+
+def trusted(path):
+    if not path or not path.startswith("/"):
+        return False
+    try:
+        real = os.path.realpath(path)
+        st = os.stat(real)
+    except OSError:
+        return False
+    if any(under(real, prefix) for prefix in blocked):
+        return False
+    if st.st_uid != 0:
+        return False
+    return not st.st_mode & (stat.S_IWGRP | stat.S_IWOTH)
+
+
 try:
     from importlib.metadata import entry_points
     try:
         eps = list(entry_points(group='pytest11'))
     except TypeError:
         eps = list(entry_points().get('pytest11', []))
-    names = sorted(set(ep.name for ep in eps))
-    print(json.dumps(names))
+    names = []
+    for ep in eps:
+        top = ep.value.split(':')[0].strip().split('.')[0]
+        if not top:
+            continue
+        try:
+            spec = PathFinder.find_spec(top)
+        except Exception:
+            continue
+        if spec is None:
+            continue
+        # A namespace package has no origin, only search locations; a builtin
+        # has a non-path origin. Requiring at least one real path keeps both
+        # from passing by vacuous truth.
+        locations = [spec.origin] if (spec.origin or "").startswith("/") else []
+        locations += [str(p) for p in (spec.submodule_search_locations or [])]
+        if not locations or not all(trusted(p) for p in locations):
+            continue
+        names.append(ep.name)
+    print(json.dumps(sorted(set(names))))
 except Exception as e:
     print(json.dumps({"error": str(e)}), file=sys.stderr)
     print("[]")
@@ -616,11 +682,27 @@ def _trusted_path_extras_cmd(raw_path: str, blocked_prefixes: tuple[str, ...]) -
     )
 
 
-async def _discover_pytest_plugin_flags(env, task: "Task") -> str:
-    """Auto-discover pytest plugins from root-owned system packages.
+def _discover_pytest_plugins_cmd(blocked_prefixes: tuple[str, ...]) -> str:
+    """Build the container-side pytest plugin discovery command."""
+    return (
+        f"python3 -c {shlex.quote(_DISCOVER_PYTEST_PLUGINS_SCRIPT)} "
+        f"{shlex.quote(_json.dumps(blocked_prefixes))}"
+    )
 
-    Runs a sandbox-side script that enumerates pytest11 entry points and
-    filters to only those whose dist-info is in a root-owned directory.
+
+async def _discover_pytest_plugin_flags(
+    env,
+    task: "Task",
+    sandbox_user: str | None = None,
+    workspace: str | None = None,
+) -> str:
+    """Auto-discover pytest plugins that resolve to root-owned code.
+
+    Runs a sandbox-side script that enumerates pytest11 entry points and keeps
+    only those whose module resolves, outside every agent-writable tree, to a
+    root-owned path -- so neither a dist-info forged in the workspace nor a
+    root-installed editable project backed by workspace source can put a plugin
+    on the verifier's ``-p`` allowlist.
     Falls back to task verifier pytest_plugins declarations if discovery fails.
     Replaces the previous hand-curated whitelist mechanism.
     """
@@ -634,7 +716,9 @@ async def _discover_pytest_plugin_flags(env, task: "Task") -> str:
     # Sandbox-side auto-discovery
     try:
         result = await env.exec(
-            f"python3 -c {shlex.quote(_DISCOVER_PYTEST_PLUGINS_SCRIPT)}",
+            _discover_pytest_plugins_cmd(
+                _blocked_verifier_path_prefixes(sandbox_user, workspace)
+            ),
             user="root",
             timeout_sec=VERIFIER_SETUP_TIMEOUT_SEC,
         )
@@ -1188,9 +1272,9 @@ async def _build_verifier_env(
     verifier_env["COVERAGE_PROCESS_START"] = ""
     verifier_env["DJANGO_SETTINGS_MODULE"] = ""
     verifier_env["CELERY_CONFIG_MODULE"] = ""
-    # Auto-discover pytest plugins from root-owned system packages and
+    # Auto-discover pytest plugins that resolve to root-owned system code, plus
     # task config declarations. Appends -p flags to the hardened base.
-    flags = await _discover_pytest_plugin_flags(env, task)
+    flags = await _discover_pytest_plugin_flags(env, task, sandbox_user, workspace)
     verifier_env["PYTEST_ADDOPTS"] = _build_pytest_addopts(
         workspace,
         flags,

--- a/tests/test_verifier_plugin_trust.py
+++ b/tests/test_verifier_plugin_trust.py
@@ -1,0 +1,286 @@
+"""Which pytest11 registrations the verifier is willing to load.
+
+Discovery output becomes the verifier's ``-p`` allowlist, so a name that
+reaches it is imported inside pytest with the power to rewrite a test report.
+The decision lives in a container-side script rather than in Python, so these
+run the real script through an interpreter with a controlled ``sys.path``
+instead of mocking ``env.exec`` -- a mock can show that a name was passed
+along, not whether it should have been.
+
+``OLD_SCRIPT`` is the form these replace, kept so the contrast is asserted
+rather than described.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+OLD_SCRIPT = r"""
+import json, sys
+try:
+    from importlib.metadata import entry_points
+    try:
+        eps = list(entry_points(group='pytest11'))
+    except TypeError:
+        eps = list(entry_points().get('pytest11', []))
+    names = sorted(set(ep.name for ep in eps))
+    print(json.dumps(names))
+except Exception as e:
+    print(json.dumps({"error": str(e)}), file=sys.stderr)
+    print("[]")
+""".strip()
+
+needs_root = pytest.mark.skipif(
+    os.geteuid() != 0,
+    reason="needs root to create the root-owned tree a trusted plugin lives in",
+)
+
+
+def _plant_registration(root, dist_name, plugin_name, module):
+    """Register ``plugin_name`` as a pytest11 entry point rooted at ``root``.
+
+    This is what ``pip`` leaves behind, and what ``importlib.metadata`` reads:
+    a ``*.dist-info`` directory holding ``entry_points.txt``. Creating one
+    needs no pip and no root, which is the point.
+    """
+    info = root / f"{dist_name}-1.0.dist-info"
+    info.mkdir(parents=True, exist_ok=True)
+    (info / "entry_points.txt").write_text(f"[pytest11]\n{plugin_name} = {module}\n")
+    (info / "METADATA").write_text(
+        f"Metadata-Version: 2.1\nName: {dist_name}\nVersion: 1.0\n"
+    )
+    return info
+
+
+def _plant_module(root, module):
+    (root / f"{module}.py").write_text("# plugin body\n")
+
+
+def _unrelated_prefix(tmp_path):
+    """A blocked prefix that cannot accidentally cover ``tmp_path``.
+
+    On Linux ``tmp_path`` sits under ``/tmp``, so passing a real runtime prefix
+    here would reject every planted tree for the wrong reason -- and quietly
+    turn the "must be rejected" cases into passes that prove nothing.
+    """
+    return str(tmp_path / "no-such-agent-tree")
+
+
+def _discover(script, *, path_entries, blocked):
+    """Run the discovery script with ``path_entries`` visible on sys.path."""
+    env = {
+        k: os.environ[k] for k in ("PATH", "HOME", "LANG", "LC_ALL") if k in os.environ
+    }
+    env["PYTHONPATH"] = ":".join(str(p) for p in path_entries)
+    argv = [sys.executable, "-c", script]
+    if "sys.argv[1]" in script:
+        argv.append(json.dumps(blocked))
+    result = subprocess.run(argv, env=env, capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout or "[]")
+
+
+@pytest.fixture
+def script():
+    from benchflow.sandbox import lockdown
+
+    return lockdown._DISCOVER_PYTEST_PLUGINS_SCRIPT
+
+
+class TestWorkspaceRegistrations:
+    """A registration the agent could have authored must not be trusted."""
+
+    def test_old_form_trusted_a_workspace_registration(self, tmp_path):
+        """The defect: enumeration alone, with nothing asked about the source.
+
+        The sandbox user owns its workspace, so creating a dist-info there is
+        an ordinary file write -- no pip, no root, nothing to intercept.
+        """
+        _plant_registration(tmp_path, "forged", "forged", "forged")
+        _plant_module(tmp_path, "forged")
+
+        found = _discover(OLD_SCRIPT, path_entries=[tmp_path], blocked=[str(tmp_path)])
+
+        assert "forged" in found
+
+    def test_a_workspace_registration_is_rejected(self, tmp_path, script):
+        _plant_registration(tmp_path, "forged", "forged", "forged")
+        _plant_module(tmp_path, "forged")
+
+        found = _discover(script, path_entries=[tmp_path], blocked=[str(tmp_path)])
+
+        assert "forged" not in found
+
+    def test_the_rejection_covers_a_dotted_entry_point(self, tmp_path, script):
+        """``pkg.plugin`` is the usual shape; only the top level is resolved."""
+        pkg = tmp_path / "forgedpkg"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text("")
+        (pkg / "plugin.py").write_text("# plugin body\n")
+        _plant_registration(tmp_path, "forgedpkg", "forged", "forgedpkg.plugin")
+
+        found = _discover(script, path_entries=[tmp_path], blocked=[str(tmp_path)])
+
+        assert "forged" not in found
+
+    def test_a_home_directory_registration_is_rejected(self, tmp_path, script):
+        """``pip install --user`` writes somewhere the sandbox user owns too."""
+        home = tmp_path / "home" / "agent" / ".local"
+        home.mkdir(parents=True)
+        _plant_registration(home, "userpkg", "userplug", "userplug")
+        _plant_module(home, "userplug")
+
+        found = _discover(
+            script, path_entries=[home], blocked=[str(tmp_path / "home" / "agent")]
+        )
+
+        assert "userplug" not in found
+
+
+class TestEditableProjects:
+    """The case a dist-info ownership check on its own would let through.
+
+    An editable install puts a root-owned dist-info in site-packages while the
+    project's *source* stays in the workspace, and adds that workspace path to
+    ``sys.path``. The registration is genuinely root-authored; the code it
+    resolves to is not.
+    """
+
+    @needs_root
+    def test_an_editable_project_backed_by_workspace_source_is_rejected(
+        self, tmp_path, script
+    ):
+        site = tmp_path / "site-packages"
+        workspace = tmp_path / "workspace"
+        site.mkdir()
+        workspace.mkdir()
+        # Registration lives with the trusted system packages ...
+        _plant_registration(site, "editable-plug", "editableplug", "editable_plug")
+        # ... while the module it names resolves into the agent's workspace.
+        _plant_module(workspace, "editable_plug")
+
+        found = _discover(
+            script, path_entries=[site, workspace], blocked=[str(workspace)]
+        )
+
+        assert "editableplug" not in found, (
+            "a root-owned registration admitted agent-owned code"
+        )
+
+    @needs_root
+    def test_a_wholly_root_owned_plugin_is_still_found(self, tmp_path, script):
+        """Guard against the fix silencing the plugins it exists to preserve.
+
+        Discovery replaced a hand-curated whitelist precisely so that
+        image-installed plugins load without per-benchmark code changes;
+        rejecting those would break the verifiers that need them.
+        """
+        site = tmp_path / "site-packages"
+        site.mkdir()
+        _plant_registration(site, "real-plug", "realplug", "realplug")
+        _plant_module(site, "realplug")
+
+        found = _discover(
+            script, path_entries=[site], blocked=[_unrelated_prefix(tmp_path)]
+        )
+
+        assert "realplug" in found
+
+
+class TestOtherWaysAgentCodeGetsReached:
+    @needs_root
+    def test_a_system_plugin_shadowed_from_the_workspace_is_rejected(
+        self, tmp_path, script
+    ):
+        """Judging the system copy is wrong when pytest imports the other one.
+
+        The registration is root-authored and the system module is root-owned,
+        but a workspace module of the same name comes first on sys.path, so
+        that is what pytest loads. The name has to be refused on the strength
+        of the file that will actually be imported.
+        """
+        site = tmp_path / "site-packages"
+        workspace = tmp_path / "workspace"
+        site.mkdir()
+        workspace.mkdir()
+        _plant_registration(site, "shadowed", "shadowplug", "shadowplug")
+        _plant_module(site, "shadowplug")
+        _plant_module(workspace, "shadowplug")
+
+        found = _discover(
+            script,
+            path_entries=[workspace, site],  # workspace wins the lookup
+            blocked=[str(workspace)],
+        )
+
+        assert "shadowplug" not in found
+
+    @needs_root
+    def test_a_root_owned_but_world_writable_plugin_is_rejected(self, tmp_path, script):
+        """Root ownership stops meaning much once anyone can write the file."""
+        loose = tmp_path / "loose"
+        loose.mkdir()
+        _plant_registration(loose, "loose-plug", "looseplug", "looseplug")
+        _plant_module(loose, "looseplug")
+        (loose / "looseplug.py").chmod(0o777)
+
+        found = _discover(
+            script, path_entries=[loose], blocked=[_unrelated_prefix(tmp_path)]
+        )
+
+        assert "looseplug" not in found
+
+
+class TestDiscoveryWiring:
+    """The prefixes the script is told to distrust have to reach it."""
+
+    def test_the_command_carries_the_agent_writable_prefixes(self):
+        from benchflow.sandbox.lockdown import (
+            _blocked_verifier_path_prefixes,
+            _discover_pytest_plugins_cmd,
+        )
+
+        cmd = _discover_pytest_plugins_cmd(
+            _blocked_verifier_path_prefixes("agent", "/app")
+        )
+
+        assert "/app" in cmd
+        assert "/home/agent" in cmd
+
+    @pytest.mark.asyncio
+    async def test_the_workspace_reaches_the_container_script(self):
+        """``_build_verifier_env`` knows the workspace; discovery must get it."""
+        from benchflow.sandbox.lockdown import _discover_pytest_plugin_flags
+
+        env = MagicMock()
+        env.exec = AsyncMock(
+            return_value=MagicMock(stdout="[]", stderr="", return_code=0)
+        )
+        task = MagicMock()
+        task.config.verifier.pytest_plugins = []
+
+        await _discover_pytest_plugin_flags(env, task, "agent", "/workspace")
+
+        sent = env.exec.call_args.args[0]
+        assert "/workspace" in sent
+        assert "/home/agent" in sent
+
+    @pytest.mark.asyncio
+    async def test_task_declared_plugins_survive_discovery_returning_nothing(self):
+        """A task's own declarations are a separate channel from discovery."""
+        from benchflow.sandbox.lockdown import _discover_pytest_plugin_flags
+
+        env = MagicMock()
+        env.exec = AsyncMock(
+            return_value=MagicMock(stdout="[]", stderr="", return_code=0)
+        )
+        task = MagicMock()
+        task.config.verifier.pytest_plugins = ["declared_plug"]
+
+        flags = await _discover_pytest_plugin_flags(env, task, "agent", "/app")
+
+        assert "-p declared_plug" in flags

--- a/tests/test_verifier_plugin_trust.py
+++ b/tests/test_verifier_plugin_trust.py
@@ -9,6 +9,8 @@ along, not whether it should have been.
 
 ``OLD_SCRIPT`` is the form these replace, kept so the contrast is asserted
 rather than described.
+
+These all guard PR #1117.
 """
 
 import json
@@ -95,7 +97,7 @@ class TestWorkspaceRegistrations:
     """A registration the agent could have authored must not be trusted."""
 
     def test_old_form_trusted_a_workspace_registration(self, tmp_path):
-        """The defect: enumeration alone, with nothing asked about the source.
+        """The defect PR #1117 fixes: enumeration, nothing asked about source.
 
         The sandbox user owns its workspace, so creating a dist-info there is
         an ordinary file write -- no pip, no root, nothing to intercept.
@@ -108,6 +110,7 @@ class TestWorkspaceRegistrations:
         assert "forged" in found
 
     def test_a_workspace_registration_is_rejected(self, tmp_path, script):
+        """Guards PR #1117: the forged dist-info no longer clears discovery."""
         _plant_registration(tmp_path, "forged", "forged", "forged")
         _plant_module(tmp_path, "forged")
 
@@ -116,7 +119,7 @@ class TestWorkspaceRegistrations:
         assert "forged" not in found
 
     def test_the_rejection_covers_a_dotted_entry_point(self, tmp_path, script):
-        """``pkg.plugin`` is the usual shape; only the top level is resolved."""
+        """Guards PR #1117 for ``pkg.plugin``, the usual entry point shape."""
         pkg = tmp_path / "forgedpkg"
         pkg.mkdir()
         (pkg / "__init__.py").write_text("")
@@ -128,7 +131,8 @@ class TestWorkspaceRegistrations:
         assert "forged" not in found
 
     def test_a_home_directory_registration_is_rejected(self, tmp_path, script):
-        """``pip install --user`` writes somewhere the sandbox user owns too."""
+        """Guards PR #1117: ``pip install --user`` also writes where the
+        sandbox user can reach."""
         home = tmp_path / "home" / "agent" / ".local"
         home.mkdir(parents=True)
         _plant_registration(home, "userpkg", "userplug", "userplug")
@@ -154,6 +158,7 @@ class TestEditableProjects:
     def test_an_editable_project_backed_by_workspace_source_is_rejected(
         self, tmp_path, script
     ):
+        """Guards PR #1117 against the case a dist-info check alone misses."""
         site = tmp_path / "site-packages"
         workspace = tmp_path / "workspace"
         site.mkdir()
@@ -173,7 +178,7 @@ class TestEditableProjects:
 
     @needs_root
     def test_a_wholly_root_owned_plugin_is_still_found(self, tmp_path, script):
-        """Guard against the fix silencing the plugins it exists to preserve.
+        """Guards PR #1117 against silencing the plugins discovery exists for.
 
         Discovery replaced a hand-curated whitelist precisely so that
         image-installed plugins load without per-benchmark code changes;
@@ -192,11 +197,62 @@ class TestEditableProjects:
 
 
 class TestOtherWaysAgentCodeGetsReached:
+    """Routes to agent code that a check on the named module alone would miss."""
+
+    @needs_root
+    def test_a_submodule_reached_through_a_widened_package_is_rejected(
+        self, tmp_path, script
+    ):
+        """Guards PR #1117 against clearing ``pkg.evil`` on ``pkg``'s merits.
+
+        A pkgutil-style namespace package runs ``extend_path`` in its
+        ``__init__``, folding every same-named directory on ``sys.path`` into
+        ``__path__`` -- the workspace included. That widening happens at import
+        time, so ``find_spec`` never sees it: the top-level package looks
+        wholly root-owned while the submodule pytest ends up importing exists
+        only in the agent's tree.
+        """
+        site = tmp_path / "site-packages"
+        workspace = tmp_path / "workspace"
+        (site / "sharedns").mkdir(parents=True)
+        (workspace / "sharedns").mkdir(parents=True)
+        (site / "sharedns" / "__init__.py").write_text(
+            '__path__ = __import__("pkgutil").extend_path(__path__, __name__)\n'
+        )
+        (workspace / "sharedns" / "evil.py").write_text("# plugin body\n")
+        _plant_registration(site, "widened", "widenedplug", "sharedns.evil")
+
+        found = _discover(
+            script, path_entries=[site, workspace], blocked=[str(workspace)]
+        )
+
+        assert "widenedplug" not in found
+
+    @needs_root
+    def test_a_root_owned_dotted_plugin_is_still_found(self, tmp_path, script):
+        """Guards PR #1117 against the walk refusing a legitimate ``pkg.plugin``.
+
+        Walking the dotted path one component at a time must still clear the
+        ordinary case, which is what most real plugins look like.
+        """
+        site = tmp_path / "site-packages"
+        (site / "realpkg").mkdir(parents=True)
+        (site / "realpkg" / "__init__.py").write_text("")
+        (site / "realpkg" / "plugin.py").write_text("# plugin body\n")
+        _plant_registration(site, "real-dotted", "realdotted", "realpkg.plugin")
+
+        found = _discover(
+            script, path_entries=[site], blocked=[_unrelated_prefix(tmp_path)]
+        )
+
+        assert "realdotted" in found
+
     @needs_root
     def test_a_system_plugin_shadowed_from_the_workspace_is_rejected(
         self, tmp_path, script
     ):
-        """Judging the system copy is wrong when pytest imports the other one.
+        """Guards PR #1117: judging the system copy is wrong when pytest
+        imports the other one.
 
         The registration is root-authored and the system module is root-owned,
         but a workspace module of the same name comes first on sys.path, so
@@ -221,7 +277,7 @@ class TestOtherWaysAgentCodeGetsReached:
 
     @needs_root
     def test_a_root_owned_but_world_writable_plugin_is_rejected(self, tmp_path, script):
-        """Root ownership stops meaning much once anyone can write the file."""
+        """Guards PR #1117: root ownership means little if anyone can write."""
         loose = tmp_path / "loose"
         loose.mkdir()
         _plant_registration(loose, "loose-plug", "looseplug", "looseplug")
@@ -239,6 +295,7 @@ class TestDiscoveryWiring:
     """The prefixes the script is told to distrust have to reach it."""
 
     def test_the_command_carries_the_agent_writable_prefixes(self):
+        """Guards PR #1117: the script is useless without the prefixes."""
         from benchflow.sandbox.lockdown import (
             _blocked_verifier_path_prefixes,
             _discover_pytest_plugins_cmd,
@@ -253,7 +310,8 @@ class TestDiscoveryWiring:
 
     @pytest.mark.asyncio
     async def test_the_workspace_reaches_the_container_script(self):
-        """``_build_verifier_env`` knows the workspace; discovery must get it."""
+        """Guards PR #1117: ``_build_verifier_env`` knows the workspace, and
+        discovery has to be told."""
         from benchflow.sandbox.lockdown import _discover_pytest_plugin_flags
 
         env = MagicMock()
@@ -271,7 +329,7 @@ class TestDiscoveryWiring:
 
     @pytest.mark.asyncio
     async def test_task_declared_plugins_survive_discovery_returning_nothing(self):
-        """A task's own declarations are a separate channel from discovery."""
+        """Guards PR #1117: a task's own declarations are a separate channel."""
         from benchflow.sandbox.lockdown import _discover_pytest_plugin_flags
 
         env = MagicMock()


### PR DESCRIPTION
Trust a pytest11 registration only when the code it resolves to is root-owned and outside every agent-writable tree, so an agent cannot put a plugin of its own on the verifier's `-p` allowlist.

Fixes #1116

## The problem

Discovery enumerated pytest11 entry points and passed every name straight through. The docstring said it "filters to only those whose dist-info is in a root-owned directory"; nothing in the script asked.

That gap is reachable without pip and without root. `importlib.metadata` reads `*.dist-info` off `sys.path`, and the verifier exec carries no `cwd`, so `test.sh` runs in the image WORKDIR — the agent's workspace. A dist-info written there lands on the allowlist, gets imported inside pytest, and a `pytest_runtest_makereport` hook rewrites the report.

## The fix

For each entry point, resolve its top-level module and require every path it resolves to be root-owned, outside the agent-writable prefixes, and not group- or other-writable. Three details decide whether this actually holds:

**Resolution goes through `PathFinder`, not an import.** Importing the module to find out where it lives would run the code the check is deciding whether to trust.

**Resolution uses the full `sys.path`, not a pre-filtered one.** The question is which file pytest will import, not which one it ideally would. A workspace module shadowing a system plugin of the same name is what gets loaded, so that is what has to be judged — filtering the search path first would inspect the clean system copy and clear a name that resolves elsewhere at grading time. A mutation swapping this back for a filtered path is caught by a test.

**The module is checked, not just the dist-info.** An editable install has a root-owned dist-info in site-packages and its source in the workspace, so a dist-info ownership check on its own — the one the old docstring described — still admits agent-owned code.

**A dotted target is walked one component at a time**, each step searching only the locations its parent declares. Checking the top level alone would clear `trusted_pkg.evil` on the strength of `trusted_pkg`, and a pkgutil-style namespace package widens its `__path__` at import time to every same-named directory on `sys.path` — the workspace included — which `find_spec` never sees. Walking the path makes a component that exists only in the workspace resolve nowhere.

The agent-writable prefixes are the existing `_blocked_verifier_path_prefixes`, already used for PATH hardening, so `/testbed` and the sandbox user's home come along for free.

## Testing

`tests/test_verifier_plugin_trust.py`, 13 tests. These run the real container-side script through an interpreter with a controlled `sys.path` rather than mocking `env.exec`, because a mock can show that a name was passed along, not whether it should have been. The pre-fix script is kept in the file so the contrast is asserted rather than described.

| Registration shape | Old version | PR version |
| --- | --- | --- |
| Root-installed, root-owned code | trusted | trusted |
| dist-info forged in the workspace | trusted | rejected |
| `pip install --user` into the sandbox user's home | trusted | rejected |
| Editable project, root dist-info, workspace source | trusted | rejected |
| System plugin shadowed by a workspace module | trusted | rejected |
| Root-owned but world-writable | trusted | rejected |
| Submodule of a widened namespace package, living only in the workspace | trusted | rejected |
| Root-installed `pkg.plugin`, the ordinary dotted shape | trusted | trusted |

Six cases need root to construct the root-owned tree they contrast against, so they skip on a normal dev box and run under CI. All 13 pass as root in a `python:3.12` container.

### Mutation testing

Seven guards removed one at a time, against eight registrations planted in a container so that each guard is the only thing rejecting at least one of them.

| Mutation | Result | Leaked |
| --- | --- | --- |
| M1 drop the `uid == 0` check | caught | agent-owned plugin outside the blocked prefixes |
| M2 drop the blocked-prefix check | caught | root-owned plugin inside `/testbed` |
| M3 drop the source-trust check (pre-fix behaviour) | caught | six of the seven hostile registrations |
| M4 accept when no real path was found | survived | — |
| M5 resolve against a pre-filtered `sys.path` | caught | system plugin shadowed from the workspace |
| M6 drop the group/other-writable check | caught | root-owned but world-writable plugin |
| M7 check only the top-level component | caught | submodule of a widened namespace package |

M3 leaks six of the seven because the dotted walk still stops the widened namespace package on its own — the two guards cover different routes rather than backing each other up.

M4 survives because it is unreachable: a builtin makes `PathFinder` return `None` and stops earlier, and a namespace package always reports search locations, so `not locations` has no witness in CPython today. It is left in as fail-closed cover for a shape that does not currently exist rather than removed.

### Regressions

`tests/test_sandbox_hardening.py` 100 passed. Full suite 6053 passed; the 11 failures in `tests/test_cli_live_progress.py` reproduce identically on an unmodified checkout (they assert on line wrapping and depend on terminal width). `ruff check` and `ruff format` clean.

## End-to-end verification

Real `bench eval run`, docker sandbox, `--sandbox-user agent`, on a task graded by `python3 -m pytest`. The oracle "agent" writes a dist-info into its workspace with a hook that rewrites failed reports.

| Run | Agent solved it | Old version | PR version |
| --- | --- | --- | --- |
| Plants the plugin, does not solve | no | **reward 1.00** | reward 0.00 |
| Plants nothing, does not solve | no | reward 0.00 | reward 0.00 |
| Solves and plants the plugin, image ships `pytest-cov` | yes | — | reward 1.00 |

The verifier command line before the fix:

```
PYTEST_ADDOPTS: -c /dev/null --confcutdir=/tests -p no:cacheprovider --rootdir=/app -p helper
1 passed in 0.00s
```

and after, on the third run — the image's own plugin still loaded, the agent's gone:

```
PYTEST_ADDOPTS: -c /dev/null --confcutdir=/tests -p no:cacheprovider --rootdir=/app -p pytest_cov
```

That third row is the one guarding against overcorrection: discovery replaced a hand-curated whitelist so image-installed plugins would load without per-benchmark code changes, and rejecting those would break the verifiers that need them.

## One note on scope

Verifiers that call the `pytest` console script instead of `python3 -m pytest` were not getting a wrong score — the injected `-p` failed to resolve and crashed grading with `ImportError: Error importing plugin "helper"`, exit code 1 on a task that would otherwise have passed. That goes away here too, since the name never reaches the allowlist, but it was a separate symptom of the same gap and is worth knowing about when reading old failures.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/1117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->