### PR TITLE
Release BenchFlow 0.7.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## 0.7.7 — 2026-09-09
+
 ### Added
 - **`network_mode: denylist` blocks a list of URLs and hosts for the agent on
   Docker and Daytona.** The task keeps internet access; `blocked_urls` and
@@ -9,6 +11,29 @@
   sandbox-user firewall, hosted search tools are switched off per harness,
   and every refused request lands in `trajectory/egress_denylist.jsonl`.
   Other backends refuse the mode at preflight. (#1113)
+
+### Fixed
+
+- **Denylist egress no longer cuts the agent off from its own model.** The
+  controller registers the running LiteLLM gateway's exact
+  `127.0.0.1:<port>` endpoint with the proxy, so clients that ignore
+  `NO_PROXY` (Gemini's Undici `ProxyAgent` tunnels even plain HTTP) still
+  reach it; the exception comes from the live gateway, never task metadata or
+  agent-supplied environment, and every other private destination stays
+  blocked. Reconnects re-register the current port. (#1118)
+- **The denylist is a shared sandbox policy, not a per-harness one.** Every
+  supported ACP harness — custom registrations included — gets the same proxy,
+  certificates, and UID firewall on primary connections and later roles alike,
+  independent of harness name, model id, or provider. (#1118)
+- **`codex-acp` sessions are configured through native ACP settings.** Hosted
+  search is switched off via `CODEX_CONFIG.web_search` (the CLI ignores `-c`
+  overrides), and Codex runs in `agent-full-access` session mode when
+  BenchFlow has already selected a non-root sandbox user, so its bubblewrap
+  sandbox is not nested inside Docker or Daytona — BenchFlow's own user,
+  filesystem restrictions, proxy, and firewall still apply. (#1118)
+- **`cryptography>=44` is a core dependency.** Denylist egress mints TLS
+  certificates on both Docker and Daytona, so the pin moved out of the
+  `sandbox-agentcore` extra. (#1118)
 
 ## 0.7.6 — 2026-09-04
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "benchflow"
-version = "0.7.7.dev0"
+version = "0.7.7"
 description = "Multi-turn agent benchmarking with ACP — run any agent, any model, any provider."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -362,7 +362,7 @@ wheels = [
 
 [[package]]
 name = "benchflow"
-version = "0.7.7.dev0"
+version = "0.7.7"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
Publish `network_mode: denylist` and set the public package version to 0.7.7.

## What ships

The 0.7.7 line is the URL/host denylist egress policy and the hardening that makes it usable in practice:

- **`network_mode: denylist` on Docker and Daytona** (#1113). The task keeps internet access while `blocked_urls` and `blocked_hosts` become unreachable for the agent — the paper a task is built from, its mirrors, and its code repository. Enforced by a root-owned loopback proxy behind the sandbox-user firewall, with hosted search switched off per harness and every refusal logged to `trajectory/egress_denylist.jsonl`. Other backends refuse the mode at preflight.
- **Denylist hardening across harnesses** (#1118). The agent's own LiteLLM gateway stays reachable (clients like Gemini's Undici `ProxyAgent` ignore `NO_PROXY`), the policy applies identically to every ACP harness and later sandbox roles, `codex-acp` is configured through native ACP settings rather than `-c` overrides, and `cryptography>=44` moves from the `sandbox-agentcore` extra to a core dependency because both backends mint TLS certificates.

## This PR

Same three-file shape as [Release BenchFlow 0.7.6](https://github.com/benchflow-ai/benchflow/pull/1103): CHANGELOG heading over the accumulated entries, `pyproject.toml` `0.7.7.dev0` -> `0.7.7`, and the matching `uv.lock` line.

## Verification

- `uv lock --check` clean
- `uv run pytest tests/test_release_version.py tests/test_release_workflow_wiring.py tests/test_release_hardening_r5.py` — 41 passed
- `TAG_NAME=v0.7.7 tools/release_version.py public-release` -> `version=0.7.7`
- `uv build --no-sources` + `twine check dist/*` — both distributions PASSED

## After merge

Push `v0.7.7` to trigger `public-release.yml` (PyPI + GitHub Release), then bump `main` to `0.7.8.dev0`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/1119" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->