### PR TITLE
Bump BenchFlow to 0.7.8.dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "benchflow"
-version = "0.7.7"
+version = "0.7.8.dev0"
 description = "Multi-turn agent benchmarking with ACP — run any agent, any model, any provider."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -362,7 +362,7 @@ wheels = [
 
 [[package]]
 name = "benchflow"
-version = "0.7.7"
+version = "0.7.8.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
Restore `main` to the next development line after the public 0.7.7 release.

## Why now

[v0.7.7](https://github.com/benchflow-ai/benchflow/releases/tag/v0.7.7) is published: `public-release.yml` uploaded both distributions to PyPI (`benchflow-0.7.7-py3-none-any.whl`, `benchflow-0.7.7.tar.gz`) and cut the GitHub Release.

While `main` carries the final `0.7.7` version, `internal-preview-release.yml` deliberately skips publishing and defers to the tag-driven public workflow (see [`docs/release.md`](https://github.com/benchflow-ai/benchflow/blob/main/docs/release.md#version-model)). Returning to `.dev0` reopens the preview line, so merges to `main` resume publishing as `0.7.8.dev<run-number>`.

## This PR

Same two-file shape as [Bump BenchFlow to 0.7.7.dev0](https://github.com/benchflow-ai/benchflow/pull/1104): `pyproject.toml` and the matching `uv.lock` line, `0.7.7` -> `0.7.8.dev0`. No CHANGELOG change — the `[Unreleased]` heading is already in place above the `0.7.7` section.

Verified: `uv lock --check` clean.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/1120" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->